### PR TITLE
Implemented persistent data system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:

--- a/assets/common/utils.gd
+++ b/assets/common/utils.gd
@@ -1,0 +1,4 @@
+class_name Utils
+
+static func push_log(arg1 = "", arg2 = "", arg3 = "", arg4 = "", arg5 = "", arg6 = "", arg7 = "", arg8 = ""):
+	print(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)

--- a/assets/common/utils.gd
+++ b/assets/common/utils.gd
@@ -1,4 +1,4 @@
 class_name Utils
 
-static func push_log(arg1 = "", arg2 = "", arg3 = "", arg4 = "", arg5 = "", arg6 = "", arg7 = "", arg8 = ""):
+static func push_info(arg1 = "", arg2 = "", arg3 = "", arg4 = "", arg5 = "", arg6 = "", arg7 = "", arg8 = ""):
 	print(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)

--- a/assets/dice/scripts/dice_test.gd
+++ b/assets/dice/scripts/dice_test.gd
@@ -5,7 +5,7 @@ const d6 = preload("res://assets/dice/scenes/physics_die_d6.tscn")
 const dice_types = [d4, d6]
 
 func _ready():
-	pass
+	PersistentData.load_file()
 
 func _input(event):
 	if event.is_action_released("ui_accept"):
@@ -20,3 +20,7 @@ func _input(event):
 func on_roll_completed(die: PhysicsDie, value: int):
 	die.roll_completed.disconnect(on_roll_completed)
 	print(value)
+	
+	ExampleData.time = Time.get_ticks_msec()
+	ExampleData.value = value
+	PersistentData.save_file()

--- a/assets/persistence/example_data.gd
+++ b/assets/persistence/example_data.gd
@@ -1,0 +1,22 @@
+extends PersistentDataSection
+
+const PD_SECTION_EXAMPLE = "example"
+const PD_SECTION_EXAMPLE_TIME = "time"
+const PD_SECTION_EXAMPLE_VALUE = "value"
+
+var time: int
+var value: int
+
+func get_tag() -> String:
+	return PD_SECTION_EXAMPLE
+
+func serialise() -> Dictionary:
+	return {
+		PD_SECTION_EXAMPLE_TIME: time,
+		PD_SECTION_EXAMPLE_VALUE: value,
+	}
+
+func deserialise(data: Dictionary) -> DeserialisationResult:
+	time = data.get(PD_SECTION_EXAMPLE_TIME, 0)
+	value = data.get(PD_SECTION_EXAMPLE_VALUE, 0)
+	return DeserialisationResult.OK

--- a/assets/persistence/persistent_data.gd
+++ b/assets/persistence/persistent_data.gd
@@ -8,7 +8,14 @@ enum DeserialisationResult {
 	FAILED = 2,
 }
 
-var save_sections : Dictionary = {}
+const PD_METADATA = "metadata"
+const PD_METADATA_SAVE_VERSION = "save_version"
+const PD_METADATA_SAVE_TIME = "save_time"
+
+const SAVE_VERSION: int = 0
+
+var save_metadata: Dictionary = {}
+var save_sections: Dictionary = {}
 
 func register_section(section: PersistentDataSection):
 	var tag = section.get_tag()
@@ -17,14 +24,27 @@ func register_section(section: PersistentDataSection):
 		return
 	save_sections[tag] = section
 
+func serialise_metadata() -> Dictionary:
+	return {
+		PD_METADATA_SAVE_VERSION: SAVE_VERSION,
+		PD_METADATA_SAVE_TIME: Time.get_datetime_string_from_system(true, true)
+	}
+
 func serialise_all_sections() -> Dictionary:
 	var save_data: Dictionary = {}
+	save_data[PD_METADATA] = serialise_metadata()
 	for section in save_sections.values():
 		save_data[section.get_tag()] = section.serialise()
 	return save_data
 
+func deserialise_metadata(data: Dictionary) -> DeserialisationResult:
+	if not data.has(PD_METADATA):
+		return DeserialisationResult.FAILED
+	save_metadata = data[PD_METADATA]
+	return DeserialisationResult.OK
+
 func deserialise_all_sections(data: Dictionary) -> DeserialisationResult:
-	var result: DeserialisationResult = DeserialisationResult.OK
+	var result: DeserialisationResult = deserialise_metadata(data)
 	for section in save_sections.values():
 		var tag = section.get_tag()
 		if not data.has(tag):
@@ -33,7 +53,7 @@ func deserialise_all_sections(data: Dictionary) -> DeserialisationResult:
 		if section_result == DeserialisationResult.FAILED:
 			push_error("Deserialisation Error: Failed to deserialise section \"", tag, "\".")
 		elif section_result == DeserialisationResult.RECOVERED:
-			push_error("Deserialisation Warning: Deserialisation of section \"", tag, "\" required recovery.")
+			push_warning("Deserialisation Warning: Deserialisation of section \"", tag, "\" required recovery.")
 		result = (section_result if section_result > result else result)
 	return result
 
@@ -55,4 +75,4 @@ func load_file():
 		var save_data = json.get_data()
 		if deserialise_all_sections(save_data) == DeserialisationResult.FAILED:
 			push_error("Deserialisation Error: Some sections failed to deserialise.")
-	print(serialise_all_sections())
+		Utils.push_log("Deserialised Data: ", save_data)

--- a/assets/persistence/persistent_data.gd
+++ b/assets/persistence/persistent_data.gd
@@ -75,4 +75,4 @@ func load_file():
 		var save_data = json.get_data()
 		if deserialise_all_sections(save_data) == DeserialisationResult.FAILED:
 			push_error("Deserialisation Error: Some sections failed to deserialise.")
-		Utils.push_log("Deserialised Data: ", save_data)
+		Utils.push_info("Deserialised Data: ", save_data)

--- a/assets/persistence/persistent_data.gd
+++ b/assets/persistence/persistent_data.gd
@@ -1,0 +1,58 @@
+extends Node
+
+const FILE_NAME = "user://savegame.save"
+
+enum DeserialisationResult {
+	OK = 0,
+	RECOVERED = 1,
+	FAILED = 2,
+}
+
+var save_sections : Dictionary = {}
+
+func register_section(section: PersistentDataSection):
+	var tag = section.get_tag()
+	if save_sections.has(tag):
+		push_warning("Registration Warning: Section tag \"", tag, "\" already registered, skipping registration.")
+		return
+	save_sections[tag] = section
+
+func serialise_all_sections() -> Dictionary:
+	var save_data: Dictionary = {}
+	for section in save_sections.values():
+		save_data[section.get_tag()] = section.serialise()
+	return save_data
+
+func deserialise_all_sections(data: Dictionary) -> DeserialisationResult:
+	var result: DeserialisationResult = DeserialisationResult.OK
+	for section in save_sections.values():
+		var tag = section.get_tag()
+		if not data.has(tag):
+			continue
+		var section_result = section.deserialise(data[tag])
+		if section_result == DeserialisationResult.FAILED:
+			push_error("Deserialisation Error: Failed to deserialise section \"", tag, "\".")
+		elif section_result == DeserialisationResult.RECOVERED:
+			push_error("Deserialisation Warning: Deserialisation of section \"", tag, "\" required recovery.")
+		result = (section_result if section_result > result else result)
+	return result
+
+func save_file():
+	var file = FileAccess.open(FILE_NAME, FileAccess.WRITE)
+	var json_string = JSON.stringify(serialise_all_sections())
+	file.store_line(json_string)
+
+func load_file():
+	if not FileAccess.file_exists(FILE_NAME):
+		return
+	var save_game = FileAccess.open(FILE_NAME, FileAccess.READ)
+	while save_game.get_position() < save_game.get_length():
+		var json = JSON.new()
+		var json_string = save_game.get_line()
+		if json.parse(json_string) != OK:
+			push_error("JSON Parse Error: ", json.get_error_message(), " in ", json_string, " at line ", json.get_error_line(), ".")
+			continue
+		var save_data = json.get_data()
+		if deserialise_all_sections(save_data) == DeserialisationResult.FAILED:
+			push_error("Deserialisation Error: Some sections failed to deserialise.")
+	print(serialise_all_sections())

--- a/assets/persistence/persistent_data_section.gd
+++ b/assets/persistence/persistent_data_section.gd
@@ -1,0 +1,19 @@
+class_name PersistentDataSection extends Node
+
+const DeserialisationResult = PersistentData.DeserialisationResult
+
+func _init():
+	reset()
+	PersistentData.register_section(self)
+
+func get_tag() -> String:
+	return "none"
+
+func serialise() -> Dictionary:
+	return {}
+
+func deserialise(_data: Dictionary) -> DeserialisationResult:
+	return DeserialisationResult.OK
+
+func reset():
+	deserialise({})

--- a/assets/validation/validation.gd
+++ b/assets/validation/validation.gd
@@ -7,8 +7,8 @@ func run_all_validations() -> bool:
 	var result = true
 	for validation in validations:
 		var v = validation.new()
-		print("- Running validation for %s..." % v._name())
-		if not v._run_validations():
+		print("- Running validation for %s..." % v.get_name())
+		if not v.run_validations():
 			print("    VALIDATION FAILED")
 			result = false
 	if result:
@@ -19,8 +19,8 @@ func run_all_validations() -> bool:
 
 class Validation:
 	
-	func _name() -> String:
+	func get_name() -> String:
 		return "Validation"
 	
-	func _run_validations() -> bool:
+	func run_validations() -> bool:
 		return true

--- a/assets/validation/validation.gd
+++ b/assets/validation/validation.gd
@@ -1,19 +1,19 @@
 class_name ValidationManager
 
-const utils = preload("res://assets/common/utils.gd") 
+const Utils = preload("res://assets/common/utils.gd") 
 const validations = []
 
 func run_all_validations() -> bool:
-	utils.push_log("Running all validations...")
+	Utils.push_info("Running all validations...")
 	var result = true
 	for validation in validations:
 		var v = validation.new()
-		utils.push_log("- Running validation for ", v.get_name(), "...")
+		Utils.push_info("- Running validation for ", v.get_name(), "...")
 		if not v.run_validations():
 			push_error("    VALIDATION FAILED")
 			result = false
 	if result:
-		utils.push_log("All validations passed!")
+		Utils.push_info("All validations passed!")
 	else:
 		push_error("Some validations failed - see above for more info.")
 	return result

--- a/assets/validation/validation.gd
+++ b/assets/validation/validation.gd
@@ -1,20 +1,21 @@
 class_name ValidationManager
 
+const utils = preload("res://assets/common/utils.gd") 
 const validations = []
 
 func run_all_validations() -> bool:
-	print("Running all validations...")
+	utils.push_log("Running all validations...")
 	var result = true
 	for validation in validations:
 		var v = validation.new()
-		print("- Running validation for %s..." % v.get_name())
+		utils.push_log("- Running validation for ", v.get_name(), "...")
 		if not v.run_validations():
-			print("    VALIDATION FAILED")
+			push_error("    VALIDATION FAILED")
 			result = false
 	if result:
-		print("All validations passed!")
+		utils.push_log("All validations passed!")
 	else:
-		print("Some validations failed - see above for more info.")
+		push_error("Some validations failed - see above for more info.")
 	return result
 
 class Validation:

--- a/project.godot
+++ b/project.godot
@@ -14,7 +14,7 @@ config/name="RNG Stronghold"
 run/main_scene="res://assets/dice/scenes/dice_test.tscn"
 config/features=PackedStringArray("4.0", "Forward Plus")
 config/icon="res://assets/common/application_icon.svg"
-config/version="0.1.1"
+config/version="0.1.2"
 
 [autoload]
 

--- a/project.godot
+++ b/project.godot
@@ -16,6 +16,11 @@ config/features=PackedStringArray("4.0", "Forward Plus")
 config/icon="res://assets/common/application_icon.svg"
 config/version="0.1.1"
 
+[autoload]
+
+PersistentData="*res://assets/persistence/persistent_data.gd"
+ExampleData="*res://assets/persistence/example_data.gd"
+
 [filesystem]
 
 import/blender/enabled=false

--- a/scripts/run_validations.gd
+++ b/scripts/run_validations.gd
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S godot -s
 extends SceneTree
 
-const validation_manager = preload("res://assets/validation/validation.gd")
+const ValidationManager = preload("res://assets/validation/validation.gd")
 
 func _init():
-	var manager = validation_manager.new()
+	var manager = ValidationManager.new()
 	var result = manager.run_all_validations()
 	quit(0 if result else 1)


### PR DESCRIPTION
This PR introduces a basic persistent data system that allows for schemad serialisation and deserialisation of a save file sections, where a "section" refers to a logical grouping of data within a save file that is encoded within its own class (see `example_data.gd` for example section authoring). Each added section must also be added as an autoload singleton in the project settings (ordered after the `PersistentData` class).

The persistence API can be used as follows: 
```py
PersistentData.load_file()
ExampleData.time = Time.get_ticks_msec()
ExampleData.value = 9000
PersistentData.save_file()
```

The `PersistentData` class will also serialise metadata at the top level, and read it back in for potential comparison. Currently this is limited to file save version and time (useful for migrations and debugging respectively).

In addition the PR adds the `utils.gd` script, with its `push_log` function. This is to be used instead of `print` for log statements, not just debugging and testing. Notice that it is oddly written with many optional params; this is to allow for forwarding of variadic arguments to `print`, such as `Utils.push_log("h", 4, "ck", 5)`. It currently supports up to 8 arguments.