### PR TITLE
Implemented debug display system

### DIFF
--- a/addons/persistent_data/persistent_data_plugin.gd
+++ b/addons/persistent_data/persistent_data_plugin.gd
@@ -1,0 +1,2 @@
+@tool
+extends EditorPlugin

--- a/addons/persistent_data/plugin.cfg
+++ b/addons/persistent_data/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Godot Persistent Data"
+description="A persistent data plugin for Godot, ideal for authoring save games."
+author="Caps Collective"
+version="0.1"
+script="persistent_data_plugin.gd"

--- a/addons/persistent_data/scripts/metadata_section.gd
+++ b/addons/persistent_data/scripts/metadata_section.gd
@@ -1,0 +1,4 @@
+class_name MetadataSection extends PersistentDataSection
+
+func _init(file: PersistentDataFile):
+	file.register_metadata(self)

--- a/addons/persistent_data/scripts/persistent_data_section.gd
+++ b/addons/persistent_data/scripts/persistent_data_section.gd
@@ -1,10 +1,10 @@
 class_name PersistentDataSection extends Object
 
-const DeserialisationResult = PersistentDataSystem.DeserialisationResult
+const DeserialisationResult = PersistentDataFile.DeserialisationResult
 
-func _init():
+func _init(file: PersistentDataFile):
 	reset()
-	PersistentDataSystem.register_section(self)
+	file.register_section(self)
 
 func get_tag() -> String:
 	return "none"

--- a/assets/debug/scenes/debug_display.tscn
+++ b/assets/debug/scenes/debug_display.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=3 format=3 uid="uid://klq80i004brf"]
+
+[ext_resource type="Script" path="res://assets/debug/scripts/debug_panel.gd" id="1_i2e26"]
+[ext_resource type="PackedScene" uid="uid://bbqbny2objppp" path="res://assets/debug/scenes/example_debug_panel.tscn" id="2_tew68"]
+
+[node name="DebugDisplay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_i2e26")
+
+[node name="Shade" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ExampleDebugPanel" parent="." instance=ExtResource("2_tew68")]
+layout_mode = 0
+offset_left = 117.0
+offset_top = 102.0
+offset_right = 317.0
+offset_bottom = 352.0

--- a/assets/debug/scenes/debug_panel.tscn
+++ b/assets/debug/scenes/debug_panel.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=3 uid="uid://c6uem6u1httu1"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_resk1"]
+font_size = 18
+
+[node name="DebugPanel" type="Panel"]
+offset_right = 200.0
+offset_bottom = 250.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = -13.0
+offset_bottom = -4.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelTitle" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Title"
+label_settings = SubResource("LabelSettings_resk1")

--- a/assets/debug/scenes/example_debug_panel.tscn
+++ b/assets/debug/scenes/example_debug_panel.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://bbqbny2objppp"]
+
+[ext_resource type="PackedScene" uid="uid://c6uem6u1httu1" path="res://assets/debug/scenes/debug_panel.tscn" id="1_p3pui"]
+[ext_resource type="Script" path="res://assets/debug/scripts/example_debug_section.gd" id="2_bk4wp"]
+
+[node name="ExampleDebugPanel" instance=ExtResource("1_p3pui")]
+script = ExtResource("2_bk4wp")
+
+[node name="PanelTitle" parent="VBoxContainer" index="0"]
+text = "Example"
+
+[node name="Button" type="Button" parent="VBoxContainer" index="1"]
+layout_mode = 2
+text = "Example Button"

--- a/assets/debug/scripts/debug_panel.gd
+++ b/assets/debug/scripts/debug_panel.gd
@@ -1,0 +1,18 @@
+extends Control
+
+signal refresh
+
+func _ready():
+	set_open(false)
+
+func _input(event):
+	if event.is_action_pressed("toggle_debug"):
+		set_open(not is_open())
+
+func is_open() -> bool:
+	return visible
+
+func set_open(open: bool):
+	visible = open
+	if visible:
+		refresh.emit()

--- a/assets/debug/scripts/example_debug_section.gd
+++ b/assets/debug/scripts/example_debug_section.gd
@@ -1,0 +1,11 @@
+extends Panel
+
+func _ready():
+	get_parent().refresh.connect(on_refresh)
+	$VBoxContainer/Button.button_up.connect(on_button_up)
+
+func on_refresh():
+	print("Refresh!")
+
+func on_button_up():
+	print("Button Up!")

--- a/assets/levels/level_bindings.gd
+++ b/assets/levels/level_bindings.gd
@@ -5,7 +5,8 @@ extends Node3D
 @export var game_cam: Camera3D
 
 func _ready():
-	PersistentDataSystem.load_file()
+	Savegame.load_file()
+	Utils.push_info("Deserialised Data: ", Savegame.get_dump())
 	for building in buildings:
 		get_node(building).selected.connect(on_building_selected)
 	dice_spawner.roll_completed.connect(on_roll_completed)
@@ -24,6 +25,6 @@ func on_building_selected(building_name, pos):
 func on_roll_completed(value: int):
 	print("Rolled: ", value)
 	
-	PersistentData.example.time = Time.get_ticks_msec()
-	PersistentData.example.value = value
-	PersistentDataSystem.save_file()
+	Savegame.example.time = Time.get_ticks_msec()
+	Savegame.example.value = value
+	Savegame.save_file()

--- a/assets/levels/main_level.tscn
+++ b/assets/levels/main_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://csvkuj4r7epl8"]
+[gd_scene load_steps=16 format=3 uid="uid://c1qqqoap4v764"]
 
 [ext_resource type="Script" path="res://assets/levels/level_bindings.gd" id="1_xhye2"]
 [ext_resource type="PackedScene" uid="uid://c0newga26wfg0" path="res://assets/camera/scenes/game_camera.tscn" id="2_lsapu"]
@@ -9,6 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://dstyy0pxjmoos" path="res://assets/buildings/scenes/wall.tscn" id="7_134cx"]
 [ext_resource type="PackedScene" uid="uid://d133oe2modrw6" path="res://assets/buildings/scenes/watermill.tscn" id="8_i7q2x"]
 [ext_resource type="PackedScene" uid="uid://bpgrqxbsrqqom" path="res://assets/dice/scenes/dice_spawner.tscn" id="9_8h5he"]
+[ext_resource type="PackedScene" uid="uid://klq80i004brf" path="res://assets/debug/scenes/debug_display.tscn" id="10_go3d5"]
 
 [sub_resource type="Environment" id="Environment_8f0bx"]
 
@@ -35,6 +36,8 @@ camera_attributes = SubResource("CameraAttributesPractical_s300m")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="WorldEnvironment"]
 transform = Transform3D(0.501511, 0.704771, -0.501781, 2.49258e-16, 0.579992, 0.814622, 0.865151, -0.408542, 0.290872, 0, 0, 0)
+
+[node name="DebugDisplay" parent="." instance=ExtResource("10_go3d5")]
 
 [node name="GameCamera" parent="." instance=ExtResource("2_lsapu")]
 transform = Transform3D(0.173648, 0.492404, -0.852868, 3.02058e-16, 0.866025, 0.5, 0.984808, -0.086824, 0.150384, -55, 30, 2.08165e-12)

--- a/assets/persistence/metadata.gd
+++ b/assets/persistence/metadata.gd
@@ -1,0 +1,24 @@
+extends MetadataSection
+
+const PD_METADATA = "metadata"
+const PD_METADATA_SAVE_VERSION = "save_version"
+const PD_METADATA_SAVE_TIME = "save_time"
+
+const SAVE_VERSION: int = 0
+
+var deserialised_metadata: Dictionary = {}
+
+func get_tag() -> String:
+	return PD_METADATA
+
+func serialise() -> Dictionary:
+	return {
+		PD_METADATA_SAVE_VERSION: SAVE_VERSION,
+		PD_METADATA_SAVE_TIME: Time.get_datetime_string_from_system(true, true)
+	}
+
+func deserialise(data: Dictionary) -> DeserialisationResult:
+	if not data.has(PD_METADATA):
+		return DeserialisationResult.FAILED
+	deserialised_metadata = data[PD_METADATA]
+	return DeserialisationResult.OK

--- a/assets/persistence/persistent_data.gd
+++ b/assets/persistence/persistent_data.gd
@@ -1,4 +1,0 @@
-extends Node
-
-const ExampleData = preload("res://assets/persistence/example_data.gd")
-@onready var example: ExampleData = ExampleData.new()

--- a/assets/persistence/savegame.gd
+++ b/assets/persistence/savegame.gd
@@ -1,0 +1,10 @@
+extends PersistentDataFile
+
+func get_file_name() -> String:
+	return "user://savegame.save"
+
+const Metadata = preload("res://assets/persistence/metadata.gd")
+@onready var metadata: Metadata = Metadata.new(self)
+
+const ExampleData = preload("res://assets/persistence/example_data.gd")
+@onready var example: ExampleData = ExampleData.new(self)

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,11 @@ config/version="0.1.3"
 PersistentDataSystem="*res://assets/persistence/persistent_data_system.gd"
 PersistentData="*res://assets/persistence/persistent_data.gd"
 
+[display]
+
+window/size/window_width_override=1920
+window/size/window_height_override=1080
+
 [filesystem]
 
 import/blender/enabled=false
@@ -35,6 +40,11 @@ lmb_down={
 rmb_down={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"pressed":false,"double_click":false,"script":null)
+]
+}
+toggle_debug={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":96,"physical_keycode":0,"key_label":0,"unicode":96,"echo":false,"script":null)
 ]
 }
 

--- a/project.godot
+++ b/project.godot
@@ -14,7 +14,7 @@ config/name="RNG Stronghold"
 run/main_scene="res://assets/levels/main_level.tscn"
 config/features=PackedStringArray("4.0", "Forward Plus")
 config/icon="res://assets/common/application_icon.svg"
-config/version="0.1.3"
+config/version="0.1.4"
 
 [autoload]
 

--- a/project.godot
+++ b/project.godot
@@ -18,13 +18,16 @@ config/version="0.1.4"
 
 [autoload]
 
-PersistentDataSystem="*res://assets/persistence/persistent_data_system.gd"
-PersistentData="*res://assets/persistence/persistent_data.gd"
+Savegame="*res://assets/persistence/savegame.gd"
 
 [display]
 
 window/size/window_width_override=1920
 window/size/window_height_override=1080
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/persistent_data/plugin.cfg")
 
 [filesystem]
 


### PR DESCRIPTION
### Pull Request Description
<!-- Provide a brief description of what this PR does and how it can be tested below -->
This PR adds a debug UI system with associated panel authoring framework, which should close #21. The system should allow for new debug panels to be created using the framework that have a uniform look and can be refreshed on open. In-game, the debug panel can be opened with the key combination of `ctrl/cmd + backtick` (depending on your system) and it should be noted that on macOS this conflicts with a system binding for changing windows that can be disabled in accessibility settings.

In addition, the PR reworks the persistent data system to allow for multiple files, custom metadata sections, and pluginifies the base. This has the added benefit of simplifying authoring and access, and only the inherited save file class is required to be listed as an autoload in the project settings.

<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Implemented walls mechanic")
- [x] linked to its related issue
- [x] assigned a reviewer from the team

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] pulled to the reviewer's machine and reasonably tested
- [x] read through and approved by a reviewer
- [x] bumped in project version over the [latest release](https://github.com/CapsCollective/rng-stronghold/releases) (i.e. vX.Y.Z for major, minor or patch)

_Note: for new features, use minor (Y), and for bug fixes or small changes, use patch (Z). Bumping the minor version should also reset the patch version to zero, so v1.2.4, would become v1.3.0. See [semantic versioning](https://semver.org) for more info._

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
