### PR TITLE
Implemented datatable plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,9 @@ on:
 env:
   APP_NAME: RNGStronghold
   BUILD_DIR: build
-  GODOT_VERSION: 4.0.3
+  GODOT_VERSION: 4.1
   GODOT_TEMPLATES_DIR: "/Users/runner/Library/Application Support/Godot/export_templates"
+  GODOT_EXECUTABLE: /Applications/Godot.app/Contents/MacOS/Godot
 
 jobs:
   build:
@@ -17,8 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
-      - name: Install Godot
-        run: brew install godot
+      - name: Setup Godot
+        run: |
+          curl -o ./godot.zip "https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_macos.universal.zip"
+          unzip ./godot.zip
+          mv ./Godot.app /Applications/Godot.app
 
       - name: Setup Godot templates
         run: |
@@ -28,12 +32,12 @@ jobs:
           mv ./templates "$GODOT_TEMPLATES_DIR/$GODOT_VERSION.stable"
 
       - name: Apply version to export information
-        run: godot --script scripts/apply_version.gd --headless
+        run: $GODOT_EXECUTABLE --script scripts/apply_version.gd --headless
         
       - name: Build macOS application
         run: |
           mkdir -p $BUILD_DIR/macos
-          godot --export-debug macOS --headless
+          $GODOT_EXECUTABLE --export-debug macOS --headless
           [ "$(ls -A $BUILD_DIR/macos)" ]
 
       - name: Compress macOS build (to preserve permissions)
@@ -47,7 +51,7 @@ jobs:
       - name: Build Windows application
         run: |
           mkdir -p $BUILD_DIR/windows
-          godot --export-debug Windows --headless
+          $GODOT_EXECUTABLE --export-debug Windows --headless
           [ "$(ls -A $BUILD_DIR/windows)" ]
 
       - uses: actions/upload-artifact@v3
@@ -58,7 +62,7 @@ jobs:
       - name: Build Linux application
         run: |
           mkdir -p $BUILD_DIR/linux
-          godot --export-debug Linux --headless
+          $GODOT_EXECUTABLE --export-debug Linux --headless
           [ "$(ls -A $BUILD_DIR/linux)" ]
 
       - name: Compress Linux build (to preserve permissions)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
           mkdir -p "$GODOT_TEMPLATES_DIR"
           mv ./templates "$GODOT_TEMPLATES_DIR/$GODOT_VERSION.stable"
 
+      - name: Open Godot editor for reimport
+        run: $GODOT_EXECUTABLE --editor --headless --quit || true
+
       - name: Apply version to export information
         run: $GODOT_EXECUTABLE --script scripts/apply_version.gd --headless
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 env:
   APP_NAME: RNGStronghold
   BUILD_DIR: build
-  GODOT_VERSION: 4.0.2
+  GODOT_VERSION: 4.0.3
   GODOT_TEMPLATES_DIR: "/Users/runner/Library/Application Support/Godot/export_templates"
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,5 +57,8 @@ jobs:
           unzip ./godot.zip
           mv ./Godot.app /Applications/Godot.app
 
+      - name: Open Godot for reimport
+        run: $GODOT_EXECUTABLE --editor --headless --quit || true
+
       - name: Run project validations
         run: $GODOT_EXECUTABLE --script scripts/run_validations.gd --headless

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,8 @@ on:
 env:
   VERSION_FILE: project.godot
   VERSION_REGEX: config\/version=\"\K[0-9.\-A-z]*
+  GODOT_VERSION: 4.1
+  GODOT_EXECUTABLE: /Applications/Godot.app/Contents/MacOS/Godot
 
 jobs:
   check-version-bump:
@@ -50,7 +52,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Godot
-        run: brew install godot
+        run: |
+          curl -o ./godot.zip "https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_macos.universal.zip"
+          unzip ./godot.zip
+          mv ./Godot.app /Applications/Godot.app
 
       - name: Run project validations
-        run: godot --script scripts/run_validations.gd --headless
+        run: $GODOT_EXECUTABLE --script scripts/run_validations.gd --headless

--- a/addons/datatable/datatable_plugin.gd
+++ b/addons/datatable/datatable_plugin.gd
@@ -1,0 +1,3 @@
+@tool
+extends EditorPlugin
+

--- a/addons/datatable/datatable_plugin.gd
+++ b/addons/datatable/datatable_plugin.gd
@@ -16,7 +16,6 @@ func _enter_tree():
 
 func _exit_tree():
 	remove_inspector_plugin(dt_inspector_plugin)
-	dt_inspector_plugin.queue_free()
 	remove_control_from_bottom_panel(dt_editor)
 	dt_editor.queue_free()
 

--- a/addons/datatable/datatable_plugin.gd
+++ b/addons/datatable/datatable_plugin.gd
@@ -1,3 +1,14 @@
 @tool
 extends EditorPlugin
 
+const DatatableEditor = preload("res://addons/datatable/scripts/datatable_editor.gd")
+
+var dt_editor: DatatableEditor
+
+func _enter_tree():
+	dt_editor = DatatableEditor.new(self)
+	add_control_to_bottom_panel(dt_editor, "Datatable Editor")
+
+func _exit_tree():
+	remove_control_from_bottom_panel(dt_editor)
+	dt_editor.queue_free()

--- a/addons/datatable/datatable_plugin.gd
+++ b/addons/datatable/datatable_plugin.gd
@@ -2,13 +2,24 @@
 extends EditorPlugin
 
 const DatatableEditor = preload("res://addons/datatable/scripts/datatable_editor.gd")
+const DatatableInspectorPlugin = preload("res://addons/datatable/scripts/datatable_inspector_plugin.gd")
 
 var dt_editor: DatatableEditor
+var dt_inspector_plugin: DatatableInspectorPlugin
 
 func _enter_tree():
 	dt_editor = DatatableEditor.new(self)
 	add_control_to_bottom_panel(dt_editor, "Datatable Editor")
+	dt_inspector_plugin = DatatableInspectorPlugin.new()
+	dt_inspector_plugin.datatable_inspected.connect(on_datatable_inspected)
+	add_inspector_plugin(dt_inspector_plugin)
 
 func _exit_tree():
+	remove_inspector_plugin(dt_inspector_plugin)
+	dt_inspector_plugin.queue_free()
 	remove_control_from_bottom_panel(dt_editor)
 	dt_editor.queue_free()
+
+func on_datatable_inspected(datatable: Datatable):
+	dt_editor.set_current_datatable(datatable)
+	make_bottom_panel_item_visible(dt_editor)

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -1,21 +1,14 @@
-[gd_resource type="Resource" script_class="Datatable" load_steps=5 format=3 uid="uid://6bhpyivuj2e7"]
+[gd_resource type="Resource" script_class="Datatable" load_steps=4 format=3 uid="uid://6bhpyivuj2e7"]
 
 [ext_resource type="Script" path="res://addons/datatable/example/example_row.gd" id="1_ip3ua"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_ty367"]
 
-[sub_resource type="Resource" id="Resource_mglup"]
-script = ExtResource("1_ip3ua")
-a = 1
-b = 2.3
-
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_ip3ua")
-a = 0
-b = 0.0
+a = null
+b = null
 
 [resource]
 script = ExtResource("2_ty367")
 default_row = SubResource("Resource_ubty6")
-data = {
-"test": SubResource("Resource_mglup")
-}
+data = {}

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -1,14 +1,56 @@
-[gd_resource type="Resource" script_class="Datatable" load_steps=4 format=3 uid="uid://6bhpyivuj2e7"]
+[gd_resource type="Resource" script_class="Datatable" load_steps=11 format=3 uid="uid://6bhpyivuj2e7"]
 
 [ext_resource type="Script" path="res://addons/datatable/example/example_row.gd" id="1_ip3ua"]
+[ext_resource type="Script" path="res://scripts/apply_version.gd" id="2_cga4q"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_ty367"]
+[ext_resource type="Script" path="res://scripts/run_validations.gd" id="3_em5q6"]
+
+[sub_resource type="Resource" id="Resource_kd8af"]
+script = ExtResource("1_ip3ua")
+value_a = 0
+value_b = 0.0
+value_c = ""
+value_d = ExtResource("2_cga4q")
+
+[sub_resource type="Resource" id="Resource_f5lgc"]
+script = ExtResource("1_ip3ua")
+value_a = 0
+value_b = 0.0
+value_c = ""
+value_d = ExtResource("3_em5q6")
+
+[sub_resource type="Resource" id="Resource_52y0o"]
+script = ExtResource("1_ip3ua")
+value_a = 0
+value_b = 0.0
+value_c = ""
+
+[sub_resource type="Resource" id="Resource_jbiqg"]
+script = ExtResource("1_ip3ua")
+value_a = 0
+value_b = 0.0
+value_c = ""
+
+[sub_resource type="Resource" id="Resource_23pe0"]
+script = ExtResource("1_ip3ua")
+value_a = 0
+value_b = 0.0
+value_c = ""
 
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_ip3ua")
-a = null
-b = null
+value_a = 0
+value_b = 0.0
+value_c = ""
 
 [resource]
 script = ExtResource("2_ty367")
+key_type = 4
 default_row = SubResource("Resource_ubty6")
-data = {}
+data = {
+"0test": SubResource("Resource_kd8af"),
+"test": SubResource("Resource_f5lgc"),
+"test1": SubResource("Resource_52y0o"),
+"test2": SubResource("Resource_jbiqg"),
+"test3": SubResource("Resource_23pe0")
+}

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -1,37 +1,27 @@
-[gd_resource type="Resource" script_class="Datatable" load_steps=11 format=3 uid="uid://6bhpyivuj2e7"]
+[gd_resource type="Resource" script_class="Datatable" load_steps=8 format=3 uid="uid://6bhpyivuj2e7"]
 
 [ext_resource type="Script" path="res://addons/datatable/example/example_row1.gd" id="1_k2jhp"]
-[ext_resource type="Script" path="res://scripts/apply_version.gd" id="2_cga4q"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_ty367"]
-[ext_resource type="Script" path="res://scripts/run_validations.gd" id="3_em5q6"]
 
-[sub_resource type="Resource" id="Resource_kd8af"]
-script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = "asoh"
-value_d = ExtResource("2_cga4q")
-
-[sub_resource type="Resource" id="Resource_f5lgc"]
-script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = "ds"
-value_d = ExtResource("3_em5q6")
-
-[sub_resource type="Resource" id="Resource_52y0o"]
+[sub_resource type="Resource" id="Resource_pedlg"]
 script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
 
-[sub_resource type="Resource" id="Resource_jbiqg"]
+[sub_resource type="Resource" id="Resource_yom6g"]
 script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
 
-[sub_resource type="Resource" id="Resource_23pe0"]
+[sub_resource type="Resource" id="Resource_jaq2w"]
+script = ExtResource("1_k2jhp")
+value_a = 0
+value_b = 0.0
+value_c = ""
+
+[sub_resource type="Resource" id="Resource_0ffkn"]
 script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
@@ -45,12 +35,11 @@ value_c = ""
 
 [resource]
 script = ExtResource("2_ty367")
-key_type = 21
+key_type = 4
 default_row = SubResource("Resource_ubty6")
 data = {
-"0testt": SubResource("Resource_kd8af"),
-"test": SubResource("Resource_f5lgc"),
-"test1": SubResource("Resource_52y0o"),
-"test2": SubResource("Resource_jbiqg"),
-"test4": SubResource("Resource_23pe0")
+"0test": SubResource("Resource_jaq2w"),
+"1": SubResource("Resource_0ffkn"),
+"hello": SubResource("Resource_pedlg"),
+"hi": SubResource("Resource_yom6g")
 }

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -1,31 +1,41 @@
-[gd_resource type="Resource" script_class="Datatable" load_steps=8 format=3 uid="uid://6bhpyivuj2e7"]
+[gd_resource type="Resource" script_class="Datatable" load_steps=9 format=3 uid="uid://6bhpyivuj2e7"]
 
 [ext_resource type="Script" path="res://addons/datatable/example/example_row1.gd" id="1_k2jhp"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_ty367"]
-
-[sub_resource type="Resource" id="Resource_pedlg"]
-script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = ""
-
-[sub_resource type="Resource" id="Resource_yom6g"]
-script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = ""
+[ext_resource type="Script" path="res://assets/camera/scripts/game_camera.gd" id="2_w522e"]
 
 [sub_resource type="Resource" id="Resource_jaq2w"]
 script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
+value_d = ExtResource("2_w522e")
+value_e = Object(Label3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":0,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":0,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"pixel_size":0.005,"offset":Vector2(0, 0),"billboard":0,"shaded":false,"double_sided":true,"no_depth_test":false,"fixed_size":false,"alpha_cut":0,"alpha_scissor_threshold":0.5,"alpha_hash_scale":1.0,"alpha_antialiasing_mode":0,"alpha_antialiasing_edge":0.0,"texture_filter":3,"render_priority":0,"outline_render_priority":-1,"modulate":Color(1, 1, 1, 1),"outline_modulate":Color(0, 0, 0, 1),"text":"","font":null,"font_size":32,"outline_size":12,"horizontal_alignment":1,"vertical_alignment":1,"uppercase":false,"line_spacing":0.0,"autowrap_mode":0,"width":500.0,"text_direction":0,"language":"","structured_text_bidi_override":0,"structured_text_bidi_override_options":[],"script":null)
+
 
 [sub_resource type="Resource" id="Resource_0ffkn"]
 script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
+value_e = Object(Sprite3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"centered":true,"offset":Vector2(0, 0),"flip_h":false,"flip_v":false,"modulate":Color(1, 1, 1, 1),"pixel_size":0.01,"axis":2,"billboard":0,"transparent":true,"shaded":false,"double_sided":true,"no_depth_test":false,"fixed_size":false,"alpha_cut":0,"alpha_scissor_threshold":0.5,"alpha_hash_scale":1.0,"alpha_antialiasing_mode":0,"alpha_antialiasing_edge":0.0,"texture_filter":3,"render_priority":0,"texture":null,"hframes":1,"vframes":1,"frame":0,"region_enabled":false,"region_rect":Rect2(0, 0, 0, 0),"script":null)
+
+
+[sub_resource type="Resource" id="Resource_pedlg"]
+script = ExtResource("1_k2jhp")
+value_a = 0
+value_b = 0.0
+value_c = ""
+value_e = Object(CPUParticles3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"emitting":true,"amount":8,"lifetime":1.0,"one_shot":false,"preprocess":0.0,"speed_scale":1.0,"explosiveness":0.0,"randomness":0.0,"lifetime_randomness":0.0,"fixed_fps":0,"fract_delta":true,"local_coords":false,"draw_order":0,"mesh":null,"emission_shape":0,"emission_colors":PackedColorArray(),"particle_flag_align_y":false,"particle_flag_rotate_y":false,"particle_flag_disable_z":false,"direction":Vector3(1, 0, 0),"spread":45.0,"flatness":0.0,"gravity":Vector3(0, -9.8, 0),"initial_velocity_min":0.0,"initial_velocity_max":0.0,"angular_velocity_min":0.0,"angular_velocity_max":0.0,"angular_velocity_curve":null,"linear_accel_min":0.0,"linear_accel_max":0.0,"linear_accel_curve":null,"radial_accel_min":0.0,"radial_accel_max":0.0,"radial_accel_curve":null,"tangential_accel_min":0.0,"tangential_accel_max":0.0,"tangential_accel_curve":null,"damping_min":0.0,"damping_max":0.0,"damping_curve":null,"angle_min":0.0,"angle_max":0.0,"angle_curve":null,"scale_amount_min":1.0,"scale_amount_max":1.0,"scale_amount_curve":null,"split_scale":false,"color":Color(1, 1, 1, 1),"color_ramp":null,"color_initial_ramp":null,"hue_variation_min":0.0,"hue_variation_max":0.0,"hue_variation_curve":null,"anim_speed_min":0.0,"anim_speed_max":0.0,"anim_speed_curve":null,"anim_offset_min":0.0,"anim_offset_max":0.0,"anim_offset_curve":null,"script":null)
+
+
+[sub_resource type="Resource" id="Resource_yom6g"]
+script = ExtResource("1_k2jhp")
+value_a = 0
+value_b = 0.0
+value_c = ""
+value_e = Object(SoftBody3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"mesh":null,"skin":null,"skeleton":NodePath(".."),"collision_layer":1,"collision_mask":1,"parent_collision_ignore":NodePath(""),"simulation_precision":5,"total_mass":1.0,"linear_stiffness":0.5,"pressure_coefficient":0.0,"damping_coefficient":0.01,"drag_coefficient":0.0,"ray_pickable":true,"disable_mode":0,"pinned_points":[],"script":null)
+
 
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_k2jhp")

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -7,7 +7,7 @@
 [sub_resource type="Resource" id="Resource_pedlg"]
 script = ExtResource("1_k2jhp")
 priority = 3.0
-move_speed = 6.999
+move_speed = 6.99
 display_name = "Ogre"
 debug_shape = "CSGTorus3D"
 

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -2,54 +2,55 @@
 
 [ext_resource type="Script" path="res://addons/datatable/example/example_row1.gd" id="1_k2jhp"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_ty367"]
-[ext_resource type="Script" path="res://assets/camera/scripts/game_camera.gd" id="2_w522e"]
+[ext_resource type="Script" path="res://addons/datatable/example/example_row2.gd" id="3_lb3a7"]
 
-[sub_resource type="Resource" id="Resource_jaq2w"]
+[sub_resource type="Resource" id="Resource_pedlg"]
 script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = ""
-value_d = ExtResource("2_w522e")
-value_e = Object(Label3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":0,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":0,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"pixel_size":0.005,"offset":Vector2(0, 0),"billboard":0,"shaded":false,"double_sided":true,"no_depth_test":false,"fixed_size":false,"alpha_cut":0,"alpha_scissor_threshold":0.5,"alpha_hash_scale":1.0,"alpha_antialiasing_mode":0,"alpha_antialiasing_edge":0.0,"texture_filter":3,"render_priority":0,"outline_render_priority":-1,"modulate":Color(1, 1, 1, 1),"outline_modulate":Color(0, 0, 0, 1),"text":"","font":null,"font_size":32,"outline_size":12,"horizontal_alignment":1,"vertical_alignment":1,"uppercase":false,"line_spacing":0.0,"autowrap_mode":0,"width":500.0,"text_direction":0,"language":"","structured_text_bidi_override":0,"structured_text_bidi_override_options":[],"script":null)
+priority = 3.0
+move_speed = 6.999
+display_name = "Ogre"
+debug_shape = Object(CSGTorus3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"inner_radius":0.5,"outer_radius":1.0,"sides":8,"ring_sides":6,"smooth_faces":true,"material":null,"script":null)
 
 
 [sub_resource type="Resource" id="Resource_0ffkn"]
 script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = ""
-value_e = Object(Sprite3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"centered":true,"offset":Vector2(0, 0),"flip_h":false,"flip_v":false,"modulate":Color(1, 1, 1, 1),"pixel_size":0.01,"axis":2,"billboard":0,"transparent":true,"shaded":false,"double_sided":true,"no_depth_test":false,"fixed_size":false,"alpha_cut":0,"alpha_scissor_threshold":0.5,"alpha_hash_scale":1.0,"alpha_antialiasing_mode":0,"alpha_antialiasing_edge":0.0,"texture_filter":3,"render_priority":0,"texture":null,"hframes":1,"vframes":1,"frame":0,"region_enabled":false,"region_rect":Rect2(0, 0, 0, 0),"script":null)
-
-
-[sub_resource type="Resource" id="Resource_pedlg"]
-script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = ""
-value_e = Object(CPUParticles3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"emitting":true,"amount":8,"lifetime":1.0,"one_shot":false,"preprocess":0.0,"speed_scale":1.0,"explosiveness":0.0,"randomness":0.0,"lifetime_randomness":0.0,"fixed_fps":0,"fract_delta":true,"local_coords":false,"draw_order":0,"mesh":null,"emission_shape":0,"emission_colors":PackedColorArray(),"particle_flag_align_y":false,"particle_flag_rotate_y":false,"particle_flag_disable_z":false,"direction":Vector3(1, 0, 0),"spread":45.0,"flatness":0.0,"gravity":Vector3(0, -9.8, 0),"initial_velocity_min":0.0,"initial_velocity_max":0.0,"angular_velocity_min":0.0,"angular_velocity_max":0.0,"angular_velocity_curve":null,"linear_accel_min":0.0,"linear_accel_max":0.0,"linear_accel_curve":null,"radial_accel_min":0.0,"radial_accel_max":0.0,"radial_accel_curve":null,"tangential_accel_min":0.0,"tangential_accel_max":0.0,"tangential_accel_curve":null,"damping_min":0.0,"damping_max":0.0,"damping_curve":null,"angle_min":0.0,"angle_max":0.0,"angle_curve":null,"scale_amount_min":1.0,"scale_amount_max":1.0,"scale_amount_curve":null,"split_scale":false,"color":Color(1, 1, 1, 1),"color_ramp":null,"color_initial_ramp":null,"hue_variation_min":0.0,"hue_variation_max":0.0,"hue_variation_curve":null,"anim_speed_min":0.0,"anim_speed_max":0.0,"anim_speed_curve":null,"anim_offset_min":0.0,"anim_offset_max":0.0,"anim_offset_curve":null,"script":null)
+priority = 2.0
+move_speed = 2.111
+display_name = "Goblin"
+combat_script = ExtResource("3_lb3a7")
+debug_shape = Object(CSGSphere3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"radius":0.5,"radial_segments":12,"rings":6,"smooth_faces":true,"material":null,"script":null)
 
 
 [sub_resource type="Resource" id="Resource_yom6g"]
 script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = ""
-value_e = Object(SoftBody3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"mesh":null,"skin":null,"skeleton":NodePath(".."),"collision_layer":1,"collision_mask":1,"parent_collision_ignore":NodePath(""),"simulation_precision":5,"total_mass":1.0,"linear_stiffness":0.5,"pressure_coefficient":0.0,"damping_coefficient":0.01,"drag_coefficient":0.0,"ray_pickable":true,"disable_mode":0,"pinned_points":[],"script":null)
+priority = 2.0
+move_speed = 3.0
+display_name = "Geoff"
+debug_shape = Object(CSGBox3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"size":Vector3(1, 1, 1),"material":null,"script":null)
+
+
+[sub_resource type="Resource" id="Resource_jaq2w"]
+script = ExtResource("1_k2jhp")
+priority = 1.0
+move_speed = 4.57
+display_name = "Hero"
+combat_script = ExtResource("1_k2jhp")
+debug_shape = Object(CSGMesh3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"mesh":null,"material":null,"script":null)
 
 
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_k2jhp")
-value_a = 0
-value_b = 0.0
-value_c = ""
+priority = 0
+move_speed = 0.0
+display_name = ""
 
 [resource]
 script = ExtResource("2_ty367")
 key_type = 4
 default_row = SubResource("Resource_ubty6")
 data = {
-"0test": SubResource("Resource_jaq2w"),
-"1": SubResource("Resource_0ffkn"),
-"hello": SubResource("Resource_pedlg"),
-"hi": SubResource("Resource_yom6g")
+"enemy_strong": SubResource("Resource_pedlg"),
+"enemy_weak": SubResource("Resource_0ffkn"),
+"npc": SubResource("Resource_yom6g"),
+"player": SubResource("Resource_jaq2w")
 }

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -10,7 +10,6 @@ priority = 3.0
 move_speed = 6.99
 display_name = "Ogre"
 debug_shape = "CSGTorus3D"
-weaknesses = 6
 
 [sub_resource type="Resource" id="Resource_0ffkn"]
 script = ExtResource("1_k2jhp")
@@ -19,7 +18,6 @@ move_speed = 2.111
 display_name = "Goblin"
 combat_script = ExtResource("3_lb3a7")
 debug_shape = "CSGSphere3D"
-weaknesses = 2
 
 [sub_resource type="Resource" id="Resource_yom6g"]
 script = ExtResource("1_k2jhp")
@@ -27,7 +25,6 @@ priority = 2.0
 move_speed = 3.0
 display_name = "Geoff"
 debug_shape = "CSGBox3D"
-weaknesses = 1
 
 [sub_resource type="Resource" id="Resource_jaq2w"]
 script = ExtResource("1_k2jhp")
@@ -36,7 +33,6 @@ move_speed = 4.57
 display_name = "Hero"
 combat_script = ExtResource("1_k2jhp")
 debug_shape = "CSGMesh3D"
-weaknesses = 5
 
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_k2jhp")
@@ -44,7 +40,6 @@ priority = 0
 move_speed = 0.0
 display_name = ""
 debug_shape = ""
-weaknesses = 0
 
 [resource]
 script = ExtResource("2_ty367")

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -10,6 +10,7 @@ priority = 3.0
 move_speed = 6.99
 display_name = "Ogre"
 debug_shape = "CSGTorus3D"
+weaknesses = 6
 
 [sub_resource type="Resource" id="Resource_0ffkn"]
 script = ExtResource("1_k2jhp")
@@ -18,6 +19,7 @@ move_speed = 2.111
 display_name = "Goblin"
 combat_script = ExtResource("3_lb3a7")
 debug_shape = "CSGSphere3D"
+weaknesses = 2
 
 [sub_resource type="Resource" id="Resource_yom6g"]
 script = ExtResource("1_k2jhp")
@@ -25,6 +27,7 @@ priority = 2.0
 move_speed = 3.0
 display_name = "Geoff"
 debug_shape = "CSGBox3D"
+weaknesses = 1
 
 [sub_resource type="Resource" id="Resource_jaq2w"]
 script = ExtResource("1_k2jhp")
@@ -33,6 +36,7 @@ move_speed = 4.57
 display_name = "Hero"
 combat_script = ExtResource("1_k2jhp")
 debug_shape = "CSGMesh3D"
+weaknesses = 5
 
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_k2jhp")
@@ -40,6 +44,7 @@ priority = 0
 move_speed = 0.0
 display_name = ""
 debug_shape = ""
+weaknesses = 0
 
 [resource]
 script = ExtResource("2_ty367")

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -9,8 +9,7 @@ script = ExtResource("1_k2jhp")
 priority = 3.0
 move_speed = 6.999
 display_name = "Ogre"
-debug_shape = Object(CSGTorus3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"inner_radius":0.5,"outer_radius":1.0,"sides":8,"ring_sides":6,"smooth_faces":true,"material":null,"script":null)
-
+debug_shape = "CSGTorus3D"
 
 [sub_resource type="Resource" id="Resource_0ffkn"]
 script = ExtResource("1_k2jhp")
@@ -18,16 +17,14 @@ priority = 2.0
 move_speed = 2.111
 display_name = "Goblin"
 combat_script = ExtResource("3_lb3a7")
-debug_shape = Object(CSGSphere3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"radius":0.5,"radial_segments":12,"rings":6,"smooth_faces":true,"material":null,"script":null)
-
+debug_shape = "CSGSphere3D"
 
 [sub_resource type="Resource" id="Resource_yom6g"]
 script = ExtResource("1_k2jhp")
 priority = 2.0
 move_speed = 3.0
 display_name = "Geoff"
-debug_shape = Object(CSGBox3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"size":Vector3(1, 1, 1),"material":null,"script":null)
-
+debug_shape = "CSGBox3D"
 
 [sub_resource type="Resource" id="Resource_jaq2w"]
 script = ExtResource("1_k2jhp")
@@ -35,14 +32,14 @@ priority = 1.0
 move_speed = 4.57
 display_name = "Hero"
 combat_script = ExtResource("1_k2jhp")
-debug_shape = Object(CSGMesh3D,"_import_path":NodePath(""),"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"editor_description":"","transform":Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0),"rotation_edit_mode":0,"rotation_order":2,"top_level":false,"visible":true,"visibility_parent":NodePath(""),"layers":1,"sorting_offset":0.0,"sorting_use_aabb_center":true,"material_override":null,"material_overlay":null,"transparency":0.0,"cast_shadow":1,"extra_cull_margin":0.0,"custom_aabb":AABB(0, 0, 0, 0, 0, 0),"lod_bias":1.0,"ignore_occlusion_culling":false,"gi_mode":1,"gi_lightmap_scale":0,"visibility_range_begin":0.0,"visibility_range_begin_margin":0.0,"visibility_range_end":0.0,"visibility_range_end_margin":0.0,"visibility_range_fade_mode":0,"operation":0,"snap":0.001,"calculate_tangents":true,"use_collision":false,"collision_layer":1,"collision_mask":1,"collision_priority":1.0,"flip_faces":false,"mesh":null,"material":null,"script":null)
-
+debug_shape = "CSGMesh3D"
 
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_k2jhp")
 priority = 0
 move_speed = 0.0
 display_name = ""
+debug_shape = ""
 
 [resource]
 script = ExtResource("2_ty367")

--- a/addons/datatable/example/example1_dt.tres
+++ b/addons/datatable/example/example1_dt.tres
@@ -1,56 +1,56 @@
 [gd_resource type="Resource" script_class="Datatable" load_steps=11 format=3 uid="uid://6bhpyivuj2e7"]
 
-[ext_resource type="Script" path="res://addons/datatable/example/example_row.gd" id="1_ip3ua"]
+[ext_resource type="Script" path="res://addons/datatable/example/example_row1.gd" id="1_k2jhp"]
 [ext_resource type="Script" path="res://scripts/apply_version.gd" id="2_cga4q"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_ty367"]
 [ext_resource type="Script" path="res://scripts/run_validations.gd" id="3_em5q6"]
 
 [sub_resource type="Resource" id="Resource_kd8af"]
-script = ExtResource("1_ip3ua")
+script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
-value_c = ""
+value_c = "asoh"
 value_d = ExtResource("2_cga4q")
 
 [sub_resource type="Resource" id="Resource_f5lgc"]
-script = ExtResource("1_ip3ua")
+script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
-value_c = ""
+value_c = "ds"
 value_d = ExtResource("3_em5q6")
 
 [sub_resource type="Resource" id="Resource_52y0o"]
-script = ExtResource("1_ip3ua")
+script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
 
 [sub_resource type="Resource" id="Resource_jbiqg"]
-script = ExtResource("1_ip3ua")
+script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
 
 [sub_resource type="Resource" id="Resource_23pe0"]
-script = ExtResource("1_ip3ua")
+script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
 
 [sub_resource type="Resource" id="Resource_ubty6"]
-script = ExtResource("1_ip3ua")
+script = ExtResource("1_k2jhp")
 value_a = 0
 value_b = 0.0
 value_c = ""
 
 [resource]
 script = ExtResource("2_ty367")
-key_type = 4
+key_type = 21
 default_row = SubResource("Resource_ubty6")
 data = {
-"0test": SubResource("Resource_kd8af"),
+"0testt": SubResource("Resource_kd8af"),
 "test": SubResource("Resource_f5lgc"),
 "test1": SubResource("Resource_52y0o"),
 "test2": SubResource("Resource_jbiqg"),
-"test3": SubResource("Resource_23pe0")
+"test4": SubResource("Resource_23pe0")
 }

--- a/addons/datatable/example/example2_dt.tres
+++ b/addons/datatable/example/example2_dt.tres
@@ -1,66 +1,34 @@
-[gd_resource type="Resource" script_class="Datatable" load_steps=11 format=3 uid="uid://b28isnouxy81n"]
+[gd_resource type="Resource" script_class="Datatable" load_steps=6 format=3 uid="uid://b28isnouxy81n"]
 
-[ext_resource type="Script" path="res://addons/datatable/example/example_row.gd" id="1_jglwc"]
+[ext_resource type="Script" path="res://addons/datatable/example/example_row2.gd" id="2_aa0pq"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_moj3i"]
 
-[sub_resource type="Resource" id="Resource_qrbu1"]
-script = ExtResource("1_jglwc")
+[sub_resource type="Resource" id="Resource_uhwms"]
+script = ExtResource("2_aa0pq")
 value_a = 0
-value_b = 0.0
-value_c = ""
+value_b = 3.0
+value_c = Color(0.278431, 0.607843, 0.603922, 1)
+value_d = 1
 
-[sub_resource type="Resource" id="Resource_lvpa0"]
-script = ExtResource("1_jglwc")
+[sub_resource type="Resource" id="Resource_y03n6"]
+script = ExtResource("2_aa0pq")
 value_a = 0
-value_b = 0.0
-value_c = "th"
+value_b = 23.0
+value_c = Color(0.196078, 0.160784, 0.478431, 1)
+value_d = 0
 
-[sub_resource type="Resource" id="Resource_bgxi2"]
-script = ExtResource("1_jglwc")
+[sub_resource type="Resource" id="Resource_c44su"]
+script = ExtResource("2_aa0pq")
 value_a = 0
 value_b = 0.0
-value_c = ""
-
-[sub_resource type="Resource" id="Resource_1pnsf"]
-script = ExtResource("1_jglwc")
-value_a = 0
-value_b = 0.0
-value_c = ""
-
-[sub_resource type="Resource" id="Resource_w63nt"]
-script = ExtResource("1_jglwc")
-value_a = 0
-value_b = 0.0
-value_c = "hell"
-
-[sub_resource type="Resource" id="Resource_wakow"]
-script = ExtResource("1_jglwc")
-value_a = 0
-value_b = 0.0
-value_c = "my2"
-
-[sub_resource type="Resource" id="Resource_p66er"]
-script = ExtResource("1_jglwc")
-value_a = 0
-value_b = 0.0
-value_c = ""
-
-[sub_resource type="Resource" id="Resource_ubty6"]
-script = ExtResource("1_jglwc")
-value_a = 0
-value_b = 0.0
-value_c = ""
+value_c = Color(0, 0, 0, 1)
+value_d = 1
 
 [resource]
 script = ExtResource("2_moj3i")
-key_type = 4
-default_row = SubResource("Resource_ubty6")
+key_type = 2
+default_row = SubResource("Resource_c44su")
 data = {
-"": SubResource("Resource_qrbu1"),
-"5": SubResource("Resource_lvpa0"),
-"76": SubResource("Resource_bgxi2"),
-"new1": SubResource("Resource_1pnsf"),
-"new_row23": SubResource("Resource_w63nt"),
-"this_is": SubResource("Resource_wakow"),
-"ub9u": SubResource("Resource_p66er")
+0: SubResource("Resource_uhwms"),
+2.0: SubResource("Resource_y03n6")
 }

--- a/addons/datatable/example/example2_dt.tres
+++ b/addons/datatable/example/example2_dt.tres
@@ -1,28 +1,35 @@
-[gd_resource type="Resource" script_class="Datatable" load_steps=6 format=3 uid="uid://b28isnouxy81n"]
+[gd_resource type="Resource" script_class="Datatable" load_steps=7 format=3 uid="uid://b28isnouxy81n"]
 
 [ext_resource type="Script" path="res://addons/datatable/example/example_row2.gd" id="2_aa0pq"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_moj3i"]
 
 [sub_resource type="Resource" id="Resource_bcl7v"]
 script = ExtResource("2_aa0pq")
-value_a = false
-value_b = Vector4(1, 3, 2, 0)
-value_c = Color(0.184314, 0.2, 0.784314, 1)
-value_d = 0
+is_enabled = true
+effect_offset = Vector4(1, 2, 3, 4)
+effect_colour = Color(0.67451, 0.227451, 0.227451, 1)
+damage_type = 0
 
 [sub_resource type="Resource" id="Resource_o8a4d"]
 script = ExtResource("2_aa0pq")
-value_a = true
-value_b = Vector4(0, 877, 77, 4)
-value_c = Color(0.172549, 0.470588, 0.411765, 1)
-value_d = 1
+is_enabled = true
+effect_offset = Vector4(50, 50, 50, 0)
+effect_colour = Color(0.145098, 0.333333, 0.835294, 1)
+damage_type = 1
+
+[sub_resource type="Resource" id="Resource_s2cjj"]
+script = ExtResource("2_aa0pq")
+is_enabled = false
+effect_offset = Vector4(0, 20, 45, 0)
+effect_colour = Color(0.462745, 0.262745, 0.623529, 1)
+damage_type = 2
 
 [sub_resource type="Resource" id="Resource_c44su"]
 script = ExtResource("2_aa0pq")
-value_a = false
-value_b = Vector4(0, 0, 0, 0)
-value_c = Color(0, 0, 0, 1)
-value_d = 1
+is_enabled = false
+effect_offset = Vector4(0, 0, 0, 0)
+effect_colour = Color(0, 0, 0, 1)
+damage_type = 0
 
 [resource]
 script = ExtResource("2_moj3i")
@@ -30,5 +37,6 @@ key_type = 2
 default_row = SubResource("Resource_c44su")
 data = {
 1: SubResource("Resource_bcl7v"),
-2: SubResource("Resource_o8a4d")
+2: SubResource("Resource_o8a4d"),
+5: SubResource("Resource_s2cjj")
 }

--- a/addons/datatable/example/example2_dt.tres
+++ b/addons/datatable/example/example2_dt.tres
@@ -1,0 +1,30 @@
+[gd_resource type="Resource" script_class="Datatable" load_steps=6 format=3 uid="uid://b28isnouxy81n"]
+
+[ext_resource type="Script" path="res://addons/datatable/example/example_row.gd" id="1_jglwc"]
+[ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_moj3i"]
+
+[sub_resource type="Resource" id="Resource_krku7"]
+script = ExtResource("1_jglwc")
+value_a = 1.0
+value_b = 0.001
+value_c = "test"
+
+[sub_resource type="Resource" id="Resource_goqdp"]
+script = ExtResource("1_jglwc")
+value_a = -1.0
+value_b = -0.001
+value_c = "hi"
+
+[sub_resource type="Resource" id="Resource_ubty6"]
+script = ExtResource("1_jglwc")
+value_a = 0
+value_b = 0.0
+value_c = ""
+
+[resource]
+script = ExtResource("2_moj3i")
+default_row = SubResource("Resource_ubty6")
+data = {
+false: SubResource("Resource_krku7"),
+"new_row": SubResource("Resource_goqdp")
+}

--- a/addons/datatable/example/example2_dt.tres
+++ b/addons/datatable/example/example2_dt.tres
@@ -3,24 +3,24 @@
 [ext_resource type="Script" path="res://addons/datatable/example/example_row2.gd" id="2_aa0pq"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_moj3i"]
 
-[sub_resource type="Resource" id="Resource_uhwms"]
+[sub_resource type="Resource" id="Resource_bcl7v"]
 script = ExtResource("2_aa0pq")
-value_a = 0
-value_b = 3.0
-value_c = Color(0.278431, 0.607843, 0.603922, 1)
-value_d = 1
-
-[sub_resource type="Resource" id="Resource_y03n6"]
-script = ExtResource("2_aa0pq")
-value_a = 0
-value_b = 23.0
-value_c = Color(0.196078, 0.160784, 0.478431, 1)
+value_a = false
+value_b = Vector4(1, 3, 2, 0)
+value_c = Color(0.184314, 0.2, 0.784314, 1)
 value_d = 0
+
+[sub_resource type="Resource" id="Resource_o8a4d"]
+script = ExtResource("2_aa0pq")
+value_a = true
+value_b = Vector4(0, 877, 77, 4)
+value_c = Color(0.172549, 0.470588, 0.411765, 1)
+value_d = 1
 
 [sub_resource type="Resource" id="Resource_c44su"]
 script = ExtResource("2_aa0pq")
-value_a = 0
-value_b = 0.0
+value_a = false
+value_b = Vector4(0, 0, 0, 0)
 value_c = Color(0, 0, 0, 1)
 value_d = 1
 
@@ -29,6 +29,6 @@ script = ExtResource("2_moj3i")
 key_type = 2
 default_row = SubResource("Resource_c44su")
 data = {
-0: SubResource("Resource_uhwms"),
-2.0: SubResource("Resource_y03n6")
+1: SubResource("Resource_bcl7v"),
+2: SubResource("Resource_o8a4d")
 }

--- a/addons/datatable/example/example2_dt.tres
+++ b/addons/datatable/example/example2_dt.tres
@@ -9,6 +9,7 @@ is_enabled = true
 effect_offset = Vector4(1, 2, 3, 4)
 effect_colour = Color(0.67451, 0.227451, 0.227451, 1)
 damage_type = 0
+weaknesses = 2
 
 [sub_resource type="Resource" id="Resource_o8a4d"]
 script = ExtResource("2_aa0pq")
@@ -16,6 +17,7 @@ is_enabled = true
 effect_offset = Vector4(50, 50, 50, 0)
 effect_colour = Color(0.145098, 0.333333, 0.835294, 1)
 damage_type = 1
+weaknesses = 5
 
 [sub_resource type="Resource" id="Resource_s2cjj"]
 script = ExtResource("2_aa0pq")
@@ -23,6 +25,7 @@ is_enabled = false
 effect_offset = Vector4(0, 20, 45, 0)
 effect_colour = Color(0.462745, 0.262745, 0.623529, 1)
 damage_type = 2
+weaknesses = 3
 
 [sub_resource type="Resource" id="Resource_c44su"]
 script = ExtResource("2_aa0pq")
@@ -30,6 +33,7 @@ is_enabled = false
 effect_offset = Vector4(0, 0, 0, 0)
 effect_colour = Color(0, 0, 0, 1)
 damage_type = 0
+weaknesses = 0
 
 [resource]
 script = ExtResource("2_moj3i")

--- a/addons/datatable/example/example2_dt.tres
+++ b/addons/datatable/example/example2_dt.tres
@@ -1,19 +1,49 @@
-[gd_resource type="Resource" script_class="Datatable" load_steps=6 format=3 uid="uid://b28isnouxy81n"]
+[gd_resource type="Resource" script_class="Datatable" load_steps=11 format=3 uid="uid://b28isnouxy81n"]
 
 [ext_resource type="Script" path="res://addons/datatable/example/example_row.gd" id="1_jglwc"]
 [ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_moj3i"]
 
-[sub_resource type="Resource" id="Resource_krku7"]
+[sub_resource type="Resource" id="Resource_qrbu1"]
 script = ExtResource("1_jglwc")
-value_a = 1.0
-value_b = 0.001
-value_c = "test"
+value_a = 0
+value_b = 0.0
+value_c = ""
 
-[sub_resource type="Resource" id="Resource_goqdp"]
+[sub_resource type="Resource" id="Resource_lvpa0"]
 script = ExtResource("1_jglwc")
-value_a = -1.0
-value_b = -0.001
-value_c = "hi"
+value_a = 0
+value_b = 0.0
+value_c = "th"
+
+[sub_resource type="Resource" id="Resource_bgxi2"]
+script = ExtResource("1_jglwc")
+value_a = 0
+value_b = 0.0
+value_c = ""
+
+[sub_resource type="Resource" id="Resource_1pnsf"]
+script = ExtResource("1_jglwc")
+value_a = 0
+value_b = 0.0
+value_c = ""
+
+[sub_resource type="Resource" id="Resource_w63nt"]
+script = ExtResource("1_jglwc")
+value_a = 0
+value_b = 0.0
+value_c = "hell"
+
+[sub_resource type="Resource" id="Resource_wakow"]
+script = ExtResource("1_jglwc")
+value_a = 0
+value_b = 0.0
+value_c = "my2"
+
+[sub_resource type="Resource" id="Resource_p66er"]
+script = ExtResource("1_jglwc")
+value_a = 0
+value_b = 0.0
+value_c = ""
 
 [sub_resource type="Resource" id="Resource_ubty6"]
 script = ExtResource("1_jglwc")
@@ -23,8 +53,14 @@ value_c = ""
 
 [resource]
 script = ExtResource("2_moj3i")
+key_type = 4
 default_row = SubResource("Resource_ubty6")
 data = {
-false: SubResource("Resource_krku7"),
-"new_row": SubResource("Resource_goqdp")
+"": SubResource("Resource_qrbu1"),
+"5": SubResource("Resource_lvpa0"),
+"76": SubResource("Resource_bgxi2"),
+"new1": SubResource("Resource_1pnsf"),
+"new_row23": SubResource("Resource_w63nt"),
+"this_is": SubResource("Resource_wakow"),
+"ub9u": SubResource("Resource_p66er")
 }

--- a/addons/datatable/example/example_dt.tres
+++ b/addons/datatable/example/example_dt.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" script_class="Datatable" load_steps=5 format=3 uid="uid://6bhpyivuj2e7"]
+
+[ext_resource type="Script" path="res://addons/datatable/example/example_row.gd" id="1_ip3ua"]
+[ext_resource type="Script" path="res://addons/datatable/scripts/datatable.gd" id="2_ty367"]
+
+[sub_resource type="Resource" id="Resource_mglup"]
+script = ExtResource("1_ip3ua")
+a = 1
+b = 2.3
+
+[sub_resource type="Resource" id="Resource_ubty6"]
+script = ExtResource("1_ip3ua")
+a = 0
+b = 0.0
+
+[resource]
+script = ExtResource("2_ty367")
+default_row = SubResource("Resource_ubty6")
+data = {
+"test": SubResource("Resource_mglup")
+}

--- a/addons/datatable/example/example_row.gd
+++ b/addons/datatable/example/example_row.gd
@@ -1,0 +1,4 @@
+class_name ExampleRow extends DatatableRow
+
+@export var a: int
+@export var b: float

--- a/addons/datatable/example/example_row.gd
+++ b/addons/datatable/example/example_row.gd
@@ -3,4 +3,4 @@ class_name ExampleRow extends DatatableRow
 @export var value_a: int
 @export var value_b: float
 @export var value_c: String
-@export var value_d: Node
+@export var value_d: GDScript

--- a/addons/datatable/example/example_row.gd
+++ b/addons/datatable/example/example_row.gd
@@ -1,4 +1,6 @@
 class_name ExampleRow extends DatatableRow
 
-@export var a: int
-@export var b: float
+@export var value_a: int
+@export var value_b: float
+@export var value_c: String
+@export var value_d: Node

--- a/addons/datatable/example/example_row1.gd
+++ b/addons/datatable/example/example_row1.gd
@@ -1,7 +1,8 @@
 class_name ExampleRow1 extends DatatableRow
 
-@export var priority: int
-@export var move_speed: float
+@export_range(0, 10) var priority: int
+@export_range(0, 10, 0.01) var move_speed: float
 @export var display_name: String
 @export var combat_script: GDScript
 @export_enum("class_name", "CSGShape3D") var debug_shape: String
+@export_flags("Fire:1", "Ice:2", "Poison:4") var weaknesses: int

--- a/addons/datatable/example/example_row1.gd
+++ b/addons/datatable/example/example_row1.gd
@@ -4,4 +4,4 @@ class_name ExampleRow1 extends DatatableRow
 @export var move_speed: float
 @export var display_name: String
 @export var combat_script: GDScript
-@export var debug_shape: CSGShape3D
+@export_enum("class_name", "CSGShape3D") var debug_shape: String

--- a/addons/datatable/example/example_row1.gd
+++ b/addons/datatable/example/example_row1.gd
@@ -1,4 +1,4 @@
-class_name ExampleRow extends DatatableRow
+class_name ExampleRow1 extends DatatableRow
 
 @export var value_a: int
 @export var value_b: float

--- a/addons/datatable/example/example_row1.gd
+++ b/addons/datatable/example/example_row1.gd
@@ -1,7 +1,7 @@
 class_name ExampleRow1 extends DatatableRow
 
-@export var value_a: int
-@export var value_b: float
-@export var value_c: String
-@export var value_d: GDScript
-@export var value_e: VisualInstance3D
+@export var priority: int
+@export var move_speed: float
+@export var display_name: String
+@export var combat_script: GDScript
+@export var debug_shape: CSGShape3D

--- a/addons/datatable/example/example_row1.gd
+++ b/addons/datatable/example/example_row1.gd
@@ -5,4 +5,3 @@ class_name ExampleRow1 extends DatatableRow
 @export var display_name: String
 @export var combat_script: GDScript
 @export_enum("class_name", "CSGShape3D") var debug_shape: String
-@export_flags("Fire:1", "Ice:2", "Poison:4") var weaknesses: int

--- a/addons/datatable/example/example_row1.gd
+++ b/addons/datatable/example/example_row1.gd
@@ -4,3 +4,4 @@ class_name ExampleRow1 extends DatatableRow
 @export var value_b: float
 @export var value_c: String
 @export var value_d: GDScript
+@export var value_e: VisualInstance3D

--- a/addons/datatable/example/example_row2.gd
+++ b/addons/datatable/example/example_row2.gd
@@ -6,3 +6,4 @@ enum DamageType { FIRE, WATER, NECROTIC }
 @export var effect_offset: Vector4
 @export var effect_colour: Color
 @export var damage_type: DamageType
+@export_flags("Earth:1", "Ice:2", "Poison:4") var weaknesses: int

--- a/addons/datatable/example/example_row2.gd
+++ b/addons/datatable/example/example_row2.gd
@@ -1,0 +1,8 @@
+class_name ExampleRow2 extends DatatableRow
+
+enum ExampleEnum { Value1, Value2 }
+
+@export var value_a: int
+@export var value_b: float
+@export var value_c: Color
+@export var value_d: ExampleEnum

--- a/addons/datatable/example/example_row2.gd
+++ b/addons/datatable/example/example_row2.gd
@@ -2,7 +2,7 @@ class_name ExampleRow2 extends DatatableRow
 
 enum ExampleEnum { Value1, Value2 }
 
-@export var value_a: int
-@export var value_b: float
+@export var value_a: bool
+@export var value_b: Vector4
 @export var value_c: Color
 @export var value_d: ExampleEnum

--- a/addons/datatable/example/example_row2.gd
+++ b/addons/datatable/example/example_row2.gd
@@ -1,8 +1,8 @@
 class_name ExampleRow2 extends DatatableRow
 
-enum ExampleEnum { Value1, Value2 }
+enum DamageType { FIRE, WATER, NECROTIC }
 
-@export var value_a: bool
-@export var value_b: Vector4
-@export var value_c: Color
-@export var value_d: ExampleEnum
+@export var is_enabled: bool
+@export var effect_offset: Vector4
+@export var effect_colour: Color
+@export var damage_type: DamageType

--- a/addons/datatable/plugin.cfg
+++ b/addons/datatable/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Godot Datatable"
+description="A datatable plugin for Godot, ideal for authoring game data in tabular format."
+author="Caps Collective"
+version="0.1"
+script="datatable_plugin.gd"

--- a/addons/datatable/scripts/datatable.gd
+++ b/addons/datatable/scripts/datatable.gd
@@ -21,43 +21,43 @@ func get_key(idx: int) -> Variant:
 		return keys[idx]
 	return null
 
-func get_row(idx: int) -> DatatableRow:
+func get_row_by_index(idx: int) -> DatatableRow:
 	var key = get_key(idx)
 	return data[key] if key != null else null
 
-func get_row_pair(idx: int) -> DatatableRowPair:
+func get_row_pair_by_index(idx: int) -> DatatableRowPair:
 	var key = get_key(idx)
 	if key != null:
 		return DatatableRowPair.new(key, data[key])
 	return null
 
-func find_row(key: Variant) -> DatatableRow:
-	return data.find_key(key)
+func get_row(key: Variant) -> DatatableRow:
+	return data.get(key)
 
-func find_row_pair(key: Variant) -> DatatableRowPair:
+func get_row_pair(key: Variant) -> DatatableRowPair:
 	var value = data.find_key(key)
 	if value != null:
 		return DatatableRowPair.new(key, value)
 	return null
 
-func should_continue():
-	return (iterator_idx < size())
-
-func _iter_init(arg):
-	iterator_idx = 0
-	return should_continue()
-
-func _iter_next(arg):
-	iterator_idx += 1
-	return should_continue()
-
-func _iter_get(arg) -> DatatableRowPair:
-	return get_row_pair(iterator_idx)
-
 func move_row(old_key, new_key):
 	var row_value = data.get(old_key)
 	data.erase(old_key)
 	data[new_key] = row_value
+
+func _iter_init(arg):
+	iterator_idx = 0
+	return iter_can_continue()
+
+func _iter_next(arg):
+	iterator_idx += 1
+	return iter_can_continue()
+
+func _iter_get(arg) -> DatatableRowPair:
+	return get_row_pair_by_index(iterator_idx)
+
+func iter_can_continue():
+	return iterator_idx < size()
 
 class DatatableRowPair:
 	var key: Variant

--- a/addons/datatable/scripts/datatable.gd
+++ b/addons/datatable/scripts/datatable.gd
@@ -3,3 +3,78 @@ class_name Datatable extends Resource
 @export var key_type: Variant.Type = TYPE_NIL
 @export var default_row: DatatableRow
 @export var data: Dictionary
+
+func is_empty() -> bool:
+	return data.is_empty()
+
+func size() -> int:
+	return data.size()
+
+func has(key: Variant) -> bool:
+	return data.has(key)
+
+func get_key(idx: int) -> Variant:
+	var keys = data.keys()
+	if idx >= 0 and idx < keys.size():
+		return keys[idx]
+	return null
+
+func get_row(idx: int) -> DatatableRow:
+	var key = get_key(idx)
+	return data[key] if key != null else null
+
+func get_row_pair(idx: int) -> DatatableRowPair:
+	var key = get_key(idx)
+	if key != null:
+		return DatatableRowPair.new(key, data[key])
+	return null
+
+func find_row(key: Variant) -> DatatableRow:
+	return data.find_key(key)
+
+func find_row_pair(key: Variant) -> DatatableRowPair:
+	var value = data.find_key(key)
+	if value != null:
+		return DatatableRowPair.new(key, value)
+	return null
+
+func get_iter() -> DatatableIterator:
+	return DatatableIterator.new(self)
+
+func move_row(old_key, new_key):
+	var row_value = data.get(old_key)
+	data.erase(old_key)
+	data[new_key] = row_value
+
+class DatatableRowPair:
+	var key: Variant
+	var row: DatatableRow
+	
+	func _init(key, row: DatatableRow):
+		self.key = key
+		self.row = row
+	
+	func _to_string() -> String:
+		return "(%s, %s)" % [key, row.to_string()]
+
+class DatatableIterator:
+	var datatable: Datatable
+	var current_idx: int
+
+	func _init(datatable: Datatable):
+		self.datatable = datatable
+		self.current_idx = 0
+
+	func should_continue():
+		return (current_idx < datatable.size())
+
+	func _iter_init(arg):
+		current_idx = 0
+		return should_continue()
+
+	func _iter_next(arg):
+		current_idx += 1
+		return should_continue()
+
+	func _iter_get(arg) -> DatatableRowPair:
+		return datatable.get_row_pair(current_idx)

--- a/addons/datatable/scripts/datatable.gd
+++ b/addons/datatable/scripts/datatable.gd
@@ -1,4 +1,5 @@
 class_name Datatable extends Resource
 
+@export var key_type: Variant.Type = TYPE_NIL
 @export var default_row: DatatableRow
 @export var data: Dictionary

--- a/addons/datatable/scripts/datatable.gd
+++ b/addons/datatable/scripts/datatable.gd
@@ -4,6 +4,8 @@ class_name Datatable extends Resource
 @export var default_row: DatatableRow
 @export var data: Dictionary
 
+var iterator_idx: int = 0
+
 func is_empty() -> bool:
 	return data.is_empty()
 
@@ -38,8 +40,19 @@ func find_row_pair(key: Variant) -> DatatableRowPair:
 		return DatatableRowPair.new(key, value)
 	return null
 
-func get_iter() -> DatatableIterator:
-	return DatatableIterator.new(self)
+func should_continue():
+	return (iterator_idx < size())
+
+func _iter_init(arg):
+	iterator_idx = 0
+	return should_continue()
+
+func _iter_next(arg):
+	iterator_idx += 1
+	return should_continue()
+
+func _iter_get(arg) -> DatatableRowPair:
+	return get_row_pair(iterator_idx)
 
 func move_row(old_key, new_key):
 	var row_value = data.get(old_key)
@@ -56,25 +69,3 @@ class DatatableRowPair:
 	
 	func _to_string() -> String:
 		return "(%s, %s)" % [key, row.to_string()]
-
-class DatatableIterator:
-	var datatable: Datatable
-	var current_idx: int
-
-	func _init(datatable: Datatable):
-		self.datatable = datatable
-		self.current_idx = 0
-
-	func should_continue():
-		return (current_idx < datatable.size())
-
-	func _iter_init(arg):
-		current_idx = 0
-		return should_continue()
-
-	func _iter_next(arg):
-		current_idx += 1
-		return should_continue()
-
-	func _iter_get(arg) -> DatatableRowPair:
-		return datatable.get_row_pair(current_idx)

--- a/addons/datatable/scripts/datatable.gd
+++ b/addons/datatable/scripts/datatable.gd
@@ -1,0 +1,4 @@
+class_name Datatable extends Resource
+
+@export var default_row: DatatableRow
+@export var data: Dictionary

--- a/addons/datatable/scripts/datatable.gd
+++ b/addons/datatable/scripts/datatable.gd
@@ -1,63 +1,85 @@
 class_name Datatable extends Resource
+## Keyed, schema-defined data structure resource for managing tabular data.
+##
+## Provides the ability to store tabular data in a way that is both keyed
+## for quick runtime access, and schema-defined for correct access, utilising
+## the [DatatableRow] resource.
 
+## The key type that will be used by the datatable as [enum Variant.Type].
 @export var key_type: Variant.Type = TYPE_NIL
+
+## The default datatable row to use for each new row entry.
 @export var default_row: DatatableRow
+
+## The data of the datatable, stored by key-row.
 @export var data: Dictionary
 
-var iterator_idx: int = 0
+var _iterator_idx: int = 0
 
+## Returns [code]true[/code] if the datatable is empty (its size is
+## [code]0[/code]).
 func is_empty() -> bool:
 	return data.is_empty()
 
+## Returns the number of rows in the datatable.
 func size() -> int:
 	return data.size()
 
+## Returns [code]true[/code] if the datatable contains a row with the given key.
 func has(key: Variant) -> bool:
 	return data.has(key)
 
-func get_key(idx: int) -> Variant:
+## Returns the key at a given index, or [code]null[/code] if it does not exist.
+func get_key_by_index(idx: int) -> Variant:
 	var keys = data.keys()
 	if idx >= 0 and idx < keys.size():
 		return keys[idx]
+	push_warning("Non-existent index ", idx, " for datatable, out of bounds")
 	return null
 
+## Returns the corresponding row for a given key, or [code]null[/code] if it
+## does not exist.
 func get_row_by_index(idx: int) -> DatatableRow:
-	var key = get_key(idx)
+	var key = get_key_by_index(idx)
 	return data[key] if key != null else null
 
+## Returns the corresponding row pair for a given key, or [code]{}[/code] if it
+## does not exist.
 func get_row_pair_by_index(idx: int) -> Dictionary:
-	var key = get_key(idx)
-	if key != null:
-		return create_row_pair(key, data[key])
-	return {}
+	var key = get_key_by_index(idx)
+	return _create_row_pair(key, data[key]) if key != null else {}
 
+## Returns the corresponding row for a given key, or [code]null[/code] if it
+## does not exist.
 func get_row(key: Variant) -> DatatableRow:
 	return data.get(key)
 
+## Returns the corresponding row pair for a given key, or [code]{}[/code] if it
+## does not exist.
 func get_row_pair(key: Variant) -> Dictionary:
 	var value = data.find_key(key)
 	if value != null:
-		return create_row_pair(key, value)
+		return _create_row_pair(key, value)
+	push_warning("Failed to find key \"", key, "\" for datatable")
 	return {}
 
+## Replaces the key of a given row by key. Note that this operation does not
+## guarentee stable ordering.
 func move_row(old_key, new_key):
 	var row_value = data.get(old_key)
 	data.erase(old_key)
 	data[new_key] = row_value
 
 func _iter_init(arg):
-	iterator_idx = 0
-	return iter_can_continue()
+	_iterator_idx = 0
+	return _iterator_idx < size()
 
 func _iter_next(arg):
-	iterator_idx += 1
-	return iter_can_continue()
+	_iterator_idx += 1
+	return _iterator_idx < size()
 
 func _iter_get(arg) -> Dictionary:
-	return get_row_pair_by_index(iterator_idx)
+	return get_row_pair_by_index(_iterator_idx)
 
-func iter_can_continue():
-	return iterator_idx < size()
-
-func create_row_pair(key: Variant, row: DatatableRow):
+func _create_row_pair(key: Variant, row: DatatableRow):
 	return {"key": key, "value": data[key]}

--- a/addons/datatable/scripts/datatable.gd
+++ b/addons/datatable/scripts/datatable.gd
@@ -25,20 +25,20 @@ func get_row_by_index(idx: int) -> DatatableRow:
 	var key = get_key(idx)
 	return data[key] if key != null else null
 
-func get_row_pair_by_index(idx: int) -> DatatableRowPair:
+func get_row_pair_by_index(idx: int) -> Dictionary:
 	var key = get_key(idx)
 	if key != null:
-		return DatatableRowPair.new(key, data[key])
-	return null
+		return create_row_pair(key, data[key])
+	return {}
 
 func get_row(key: Variant) -> DatatableRow:
 	return data.get(key)
 
-func get_row_pair(key: Variant) -> DatatableRowPair:
+func get_row_pair(key: Variant) -> Dictionary:
 	var value = data.find_key(key)
 	if value != null:
-		return DatatableRowPair.new(key, value)
-	return null
+		return create_row_pair(key, value)
+	return {}
 
 func move_row(old_key, new_key):
 	var row_value = data.get(old_key)
@@ -53,19 +53,11 @@ func _iter_next(arg):
 	iterator_idx += 1
 	return iter_can_continue()
 
-func _iter_get(arg) -> DatatableRowPair:
+func _iter_get(arg) -> Dictionary:
 	return get_row_pair_by_index(iterator_idx)
 
 func iter_can_continue():
 	return iterator_idx < size()
 
-class DatatableRowPair:
-	var key: Variant
-	var row: DatatableRow
-	
-	func _init(key, row: DatatableRow):
-		self.key = key
-		self.row = row
-	
-	func _to_string() -> String:
-		return "(%s, %s)" % [key, row.to_string()]
+func create_row_pair(key: Variant, row: DatatableRow):
+	return {"key": key, "value": data[key]}

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -8,6 +8,7 @@ var add_row_btn: Button
 var grid_container: GridContainer
 var none_lbl: Label
 var empty_lbl: Label
+var table_scroll: ScrollContainer
 var new_dt_btn: Button
 
 var current_dt: Datatable
@@ -88,7 +89,7 @@ func rebuild_layout():
 	empty_lbl.anchors_preset = Control.PRESET_CENTER
 	table_panel.add_child(empty_lbl)
 	
-	var table_scroll = ScrollContainer.new()
+	table_scroll = ScrollContainer.new()
 	table_scroll.layout_mode = 1
 	table_scroll.anchors_preset = Control.PRESET_FULL_RECT
 	table_panel.add_child(table_scroll)
@@ -306,6 +307,11 @@ func on_add_btn_pressed():
 	if not current_dt.data.has(new_key):
 		current_dt.data[new_key] = current_dt.default_row.duplicate()
 		refresh_table()
+		
+		# Wait for next frame to allow for scroll values to update
+		await get_tree().process_frame
+		var max_scroll = table_scroll.get_v_scroll_bar().max_value
+		table_scroll.scroll_vertical = max_scroll
 
 func on_delete_btn_pressed(row):
 	current_dt.data.erase(row)
@@ -357,6 +363,7 @@ func on_new_dt_btn_pressed():
 
 func create_new_dt_resource(key_type: Variant.Type, resource_type: Resource):
 	if resource_type == null:
+		push_warning("Failed to create new datatable resource with empty row type")
 		return
 	
 	var editor = editor_plugin.get_editor_interface().get_editor_main_screen()

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -3,6 +3,7 @@ extends Control
 var datatable_name_lbl: Label
 var row_type_lbl: Label
 var row_count_lbl: Label
+var refresh_btn: Button
 var add_row_btn: Button
 var grid_container: GridContainer
 var none_lbl: Label
@@ -16,14 +17,17 @@ func _init(plugin: EditorPlugin):
 	editor_plugin = plugin
 
 func _ready():
-	build_layout()
+	rebuild_layout()
 	refresh_table()
 
 func set_current_datatable(datatable: Datatable):
 	current_dt = datatable
 	refresh_table()
 
-func build_layout():
+func rebuild_layout():
+	for child in get_children():
+		child.queue_free()
+	
 	custom_minimum_size.y = 200 * editor_plugin.get_editor_interface().get_editor_scale()
 	anchors_preset = PRESET_BOTTOM_WIDE
 	size_flags_vertical = Control.SIZE_SHRINK_BEGIN | Control.SIZE_EXPAND
@@ -57,6 +61,11 @@ func build_layout():
 	top_hbox.add_child(new_dt_btn)
 	
 	top_hbox.add_spacer(false)
+	
+	refresh_btn = Button.new()
+	refresh_btn.text = "Refresh"
+	refresh_btn.pressed.connect(on_refresh_btn_pressed)
+	top_hbox.add_child(refresh_btn)
 	
 	add_row_btn = Button.new()
 	add_row_btn.text = "Add Row"
@@ -105,6 +114,7 @@ func populate_table():
 		empty_lbl.visible = false
 		row_count_lbl.visible = false
 		row_type_lbl.visible = false
+		refresh_btn.disabled = true
 		add_row_btn.disabled = true
 		grid_container.visible = false
 		return
@@ -117,6 +127,7 @@ func populate_table():
 	empty_lbl.visible = current_dt.data.is_empty()
 	row_count_lbl.visible = true
 	row_type_lbl.visible = true
+	refresh_btn.disabled = false
 	add_row_btn.disabled = false
 	grid_container.visible = true
 	grid_container.columns = row_properties.size() + 3
@@ -261,6 +272,10 @@ func get_default_key(type: Variant.Type):
 			return String()
 		TYPE_INT:
 			return 0
+
+func on_refresh_btn_pressed():
+	rebuild_layout()
+	refresh_table()
 
 func on_add_btn_pressed():
 	var new_key = get_default_key(current_dt.key_type)

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -172,7 +172,7 @@ func populate_row(index: int, key):
 func build_field_control_for_key(value: Variant, type: Variant.Type):
 	var setter_callback = func(k):
 		if not current_dt.data.has(k):
-			move_row_stable(value, k)
+			DatatableUtils.move_row_stable(current_dt, value, k)
 			ResourceSaver.save(current_dt)
 		refresh_table()
 	var field_control

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -227,6 +227,8 @@ func build_field_control(value: Variant, property: Dictionary, setter_callback: 
 				field_control.text = value
 				if is_key:
 					field_control.text_submitted.connect(setter_callback)
+					var mark_dirty = func(i): field_control.add_theme_color_override("font_color", Color.INDIAN_RED)
+					field_control.text_changed.connect(mark_dirty)
 				else:
 					field_control.text_changed.connect(setter_callback)
 		TYPE_INT, TYPE_FLOAT:

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -350,6 +350,7 @@ func create_new_dt_resource(key_type: Variant.Type, resource_type: Resource):
 	var on_file_dialog_file_selected = func(file):
 		ResourceSaver.save(new_dt, file)
 		file_dialog.queue_free()
+		set_current_datatable(new_dt)
 	file_dialog.file_selected.connect(on_file_dialog_file_selected)
 	editor.add_child(file_dialog)
 	

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -242,8 +242,17 @@ func build_field_control(value: Variant, property: Dictionary, setter_callback: 
 				field_control = SpinBox.new()
 				field_control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 				if (property.type == TYPE_FLOAT): field_control.step = 0.001
-				field_control.allow_lesser = true
-				field_control.allow_greater = true
+				if property.hint == PROPERTY_HINT_RANGE:
+					var range_values = property.hint_string.split(",")
+					field_control.min_value = float(range_values[0])
+					field_control.max_value = float(range_values[1])
+					field_control.allow_lesser = false
+					field_control.allow_greater = false
+					if range_values.size() > 2:
+						field_control.step = float(range_values[2])
+				else:
+					field_control.allow_lesser = true
+					field_control.allow_greater = true
 				field_control.value = value
 				field_control.value_changed.connect(setter_callback)
 		TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I:

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -227,6 +227,11 @@ func build_field_control(value: Variant, property: Dictionary, setter_callback: 
 				field_control.allow_greater = true
 				field_control.value = value
 				field_control.value_changed.connect(setter_callback)
+		TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I:
+			field_control = DatatableEditorUtils.VectorEdit.new()
+			field_control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+			field_control.vector = value
+			field_control.value_changed.connect(setter_callback)
 		TYPE_COLOR:
 			field_control = ColorPickerButton.new()
 			field_control.size_flags_horizontal = Control.SIZE_EXPAND_FILL

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -1,13 +1,15 @@
 extends Control
 
 var datatable_name_lbl: Label
+var row_type_lbl: Label
 var row_count_lbl: Label
 var add_row_btn: Button
 var grid_container: GridContainer
+var none_lbl: Label
 var empty_lbl: Label
 var new_dt_btn: Button
 
-var current_dt: Dictionary
+var current_dt: Datatable
 var editor_plugin: EditorPlugin
 
 func _init(plugin: EditorPlugin):
@@ -16,9 +18,8 @@ func _init(plugin: EditorPlugin):
 func _ready():
 	build_layout()
 	refresh_table()
-	on_datatable_selected({ "hi": "hello", "bye": "goodbye" })
 
-func on_datatable_selected(datatable):
+func set_current_datatable(datatable: Datatable):
 	current_dt = datatable
 	refresh_table()
 
@@ -38,6 +39,10 @@ func build_layout():
 	datatable_name_lbl = Label.new()
 	datatable_name_lbl.text = "Datatable"
 	top_hbox.add_child(datatable_name_lbl)
+	
+	row_type_lbl = Label.new()
+	row_type_lbl.text = "[]"
+	top_hbox.add_child(row_type_lbl)
 	
 	row_count_lbl = Label.new()
 	row_count_lbl.text = "(0 rows)"
@@ -65,8 +70,14 @@ func build_layout():
 	table_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	main_vbox.add_child(table_panel)
 	
+	none_lbl = Label.new()
+	none_lbl.text = "Select a datatable resource to edit it here."
+	none_lbl.layout_mode = 1
+	none_lbl.anchors_preset = Control.PRESET_CENTER
+	table_panel.add_child(none_lbl)
+	
 	empty_lbl = Label.new()
-	empty_lbl.text = "Select a datatable resource to edit it here."
+	empty_lbl.text = "No rows in datatable."
 	empty_lbl.layout_mode = 1
 	empty_lbl.anchors_preset = Control.PRESET_CENTER
 	table_panel.add_child(empty_lbl)
@@ -87,73 +98,95 @@ func refresh_table():
 
 func reset_table():
 	for child in grid_container.get_children():
-		grid_container.remove_child(child)
 		child.queue_free()
 	datatable_name_lbl.text = "No Datatable Selected"
 	row_count_lbl.text = "(0 rows)"
 
 func populate_table():
-	var has_table = not current_dt.is_empty()
-	empty_lbl.visible = not has_table
-	add_row_btn.disabled = not has_table
-	grid_container.visible = has_table
-	grid_container.columns = 5
+	if not current_dt:
+		none_lbl.visible = true
+		empty_lbl.visible = false
+		row_count_lbl.visible = false
+		row_type_lbl.visible = false
+		add_row_btn.disabled = true
+		grid_container.visible = false
+		return
 	
-	if has_table:
-		datatable_name_lbl.text = "my_datatable.res"
-		row_count_lbl.text = "(%d rows)" % current_dt.size()
+	var row_properties = DatatableUtils.get_row_properties(current_dt.default_row)
+	var row_name = DatatableUtils.get_row_name(current_dt.default_row)
+	var row_count = current_dt.data.size()
 	
-	var header_idx_lbl = Label.new()
-	header_idx_lbl.text = "Row"
-	grid_container.add_child(header_idx_lbl)
-	for i in range(0, 3):
+	none_lbl.visible = false
+	empty_lbl.visible = current_dt.data.is_empty()
+	row_count_lbl.visible = true
+	row_type_lbl.visible = true
+	add_row_btn.disabled = false
+	grid_container.visible = true
+	grid_container.columns = row_properties.size() + 2
+	datatable_name_lbl.text = current_dt.resource_path
+	row_count_lbl.text = "(%d rows)" % row_count
+	row_type_lbl.text = "[%s]" % row_name
+	
+	if row_count <= 0:
+		return
+	
+	grid_container.add_child(Control.new())
+	for property in row_properties:
 		var header_lbl = Label.new()
-		header_lbl.text = "Header"
+		header_lbl.text = property.name
 		grid_container.add_child(header_lbl)
 	grid_container.add_child(Control.new())
+	
+	var row_index = 0
+	for key in current_dt.data:
+		row_index += 1
+		populate_row(row_index, key)
 
-	for key in current_dt:
-		populate_row(key)
-
-func populate_row(key):
+func populate_row(index: int, key):
 	var idx_lbl = Label.new()
-	idx_lbl.text = "1"
+	idx_lbl.text = " %s " % index
+	idx_lbl.add_theme_color_override("font_color", Color(1, 1, 1, 0.5))
 	idx_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	grid_container.add_child(idx_lbl)
-	for i in range(0, 3):
-		populate_cell(i)
+	var row_properties = DatatableUtils.get_row_properties(current_dt.data[key])
+	for property in row_properties:
+		populate_cell(property, key)
 	var menu_btn = MenuButton.new()
 	menu_btn.get_popup().add_item("Delete", 0)
 	menu_btn.icon = get_theme_icon("GuiTabMenuHl", "EditorIcons")
 	menu_btn.get_popup().id_pressed.connect(func(id): if id == 0: on_delete_btn_pressed(key))
 	grid_container.add_child(menu_btn)
 
-func populate_cell(i):
-	var types = ["example", true, 7.2]
-	var value = types[i]
+func populate_cell(row_property, key):
+	var set_value = func(v): current_dt.data[key].set(row_property.name, v)
 	var field_control
-	match(typeof(value)):
+	match(row_property.type):
 		TYPE_BOOL:
 			field_control = CheckBox.new()
-			field_control.button_pressed = value
+			field_control.button_pressed = row_property.value
+			field_control.toggled.connect(set_value)
 		TYPE_STRING:
 			field_control = LineEdit.new()
-			field_control.text = value
+			field_control.text = row_property.value
+			field_control.text_changed.connect(set_value)
 		TYPE_INT:
 			field_control = SpinBox.new()
 			field_control.allow_lesser = true
 			field_control.allow_greater = true
-			field_control.value = value
+			field_control.value = row_property.value
+			field_control.value_changed.connect(set_value)
 		TYPE_FLOAT:
 			field_control = SpinBox.new()
 			field_control.step = 0.001
 			field_control.allow_lesser = true
 			field_control.allow_greater = true
-			field_control.value = value
+			field_control.value = row_property.value
+			field_control.value_changed.connect(set_value)
 		TYPE_OBJECT:
 			field_control = EditorResourcePicker.new()
-			field_control.edited_resource = value
-			field_control.base_type = "Node"
+			field_control.edited_resource = row_property.value
+			#field_control.base_type = "Node"
+			field_control.resource_changed.connect(set_value)
 		_:
 			field_control = Label.new()
 			field_control.add_theme_color_override("font_color", Color(1, 0, 0))
@@ -161,12 +194,12 @@ func populate_cell(i):
 	grid_container.add_child(field_control)
 
 func on_add_btn_pressed():
-	print("adding new row...")
-	on_datatable_selected({ "hi": "hello", "bye": "goodbye", "why": "goodbye"})
+	current_dt.data["new_row"] = current_dt.default_row.duplicate()
+	refresh_table()
 
 func on_delete_btn_pressed(row):
-	print("deleting row ", row, "...")
-	on_datatable_selected({ "hi": "hello", "bye": "goodbye" })
+	current_dt.data.erase(row)
+	refresh_table()
 
 func on_new_dt_btn_pressed():
 	var editor = editor_plugin.get_editor_interface().get_editor_main_screen()
@@ -186,6 +219,7 @@ func on_new_dt_btn_pressed():
 	var on_type_btn_pressed_callback = func():
 		create_new_dt_resource(resource_picker.edited_resource)
 		popup.hide()
+		popup.queue_free()
 	type_btn.pressed.connect(on_type_btn_pressed_callback)
 	popup_vbox.add_child(type_btn)
 	
@@ -205,7 +239,10 @@ func create_new_dt_resource(resource_type: Resource):
 	file_dialog.access = EditorFileDialog.ACCESS_RESOURCES
 	file_dialog.title = "Save New Datatable"
 	file_dialog.add_filter("*.tres", "Datatable Resource")
-	file_dialog.file_selected.connect(func(p): ResourceSaver.save(new_dt, p))
+	var on_file_dialog_file_selected = func(file):
+		ResourceSaver.save(new_dt, file)
+		file_dialog.queue_free()
+	file_dialog.file_selected.connect(on_file_dialog_file_selected)
 	editor.add_child(file_dialog)
 	
 	# Can only be called after the node has entered the tree

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -1,0 +1,213 @@
+extends Control
+
+var datatable_name_lbl: Label
+var row_count_lbl: Label
+var add_row_btn: Button
+var grid_container: GridContainer
+var empty_lbl: Label
+var new_dt_btn: Button
+
+var current_dt: Dictionary
+var editor_plugin: EditorPlugin
+
+func _init(plugin: EditorPlugin):
+	editor_plugin = plugin
+
+func _ready():
+	build_layout()
+	refresh_table()
+	on_datatable_selected({ "hi": "hello", "bye": "goodbye" })
+
+func on_datatable_selected(datatable):
+	current_dt = datatable
+	refresh_table()
+
+func build_layout():
+	custom_minimum_size.y = 500
+	anchors_preset = PRESET_BOTTOM_WIDE
+	size_flags_vertical = Control.SIZE_SHRINK_BEGIN | Control.SIZE_EXPAND
+	
+	var main_vbox = VBoxContainer.new()
+	main_vbox.layout_mode = 1
+	main_vbox.anchors_preset = Control.PRESET_FULL_RECT
+	add_child(main_vbox)
+	
+	var top_hbox = HBoxContainer.new()
+	main_vbox.add_child(top_hbox)
+	
+	datatable_name_lbl = Label.new()
+	datatable_name_lbl.text = "Datatable"
+	top_hbox.add_child(datatable_name_lbl)
+	
+	row_count_lbl = Label.new()
+	row_count_lbl.text = "(0 rows)"
+	top_hbox.add_child(row_count_lbl)
+	
+	new_dt_btn = Button.new()
+	new_dt_btn.flat = true
+	new_dt_btn.expand_icon = true
+	new_dt_btn.custom_minimum_size.x = 52
+	new_dt_btn.custom_minimum_size.y = 52
+	new_dt_btn.theme = theme
+	new_dt_btn.icon = get_theme_icon("New", "EditorIcons")
+	new_dt_btn.tooltip_text = "Create a new datatable."
+	new_dt_btn.pressed.connect(on_new_dt_btn_pressed)
+	top_hbox.add_child(new_dt_btn)
+	
+	top_hbox.add_spacer(false)
+	
+	add_row_btn = Button.new()
+	add_row_btn.text = "Add Row"
+	add_row_btn.pressed.connect(on_add_btn_pressed)
+	top_hbox.add_child(add_row_btn)
+	
+	var table_panel = Panel.new()
+	table_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	main_vbox.add_child(table_panel)
+	
+	empty_lbl = Label.new()
+	empty_lbl.text = "Select a datatable resource to edit it here."
+	empty_lbl.layout_mode = 1
+	empty_lbl.anchors_preset = Control.PRESET_CENTER
+	table_panel.add_child(empty_lbl)
+	
+	var table_scroll = ScrollContainer.new()
+	table_scroll.layout_mode = 1
+	table_scroll.anchors_preset = Control.PRESET_FULL_RECT
+	table_panel.add_child(table_scroll)
+	
+	grid_container = GridContainer.new()
+	grid_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	grid_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	table_scroll.add_child(grid_container)
+
+func refresh_table():
+	reset_table()
+	populate_table()
+
+func reset_table():
+	for child in grid_container.get_children():
+		grid_container.remove_child(child)
+		child.queue_free()
+	datatable_name_lbl.text = "No Datatable Selected"
+	row_count_lbl.text = "(0 rows)"
+
+func populate_table():
+	var has_table = not current_dt.is_empty()
+	empty_lbl.visible = not has_table
+	add_row_btn.disabled = not has_table
+	grid_container.visible = has_table
+	grid_container.columns = 5
+	
+	if has_table:
+		datatable_name_lbl.text = "my_datatable.res"
+		row_count_lbl.text = "(%d rows)" % current_dt.size()
+	
+	var header_idx_lbl = Label.new()
+	header_idx_lbl.text = "Row"
+	grid_container.add_child(header_idx_lbl)
+	for i in range(0, 3):
+		var header_lbl = Label.new()
+		header_lbl.text = "Header"
+		grid_container.add_child(header_lbl)
+	grid_container.add_child(Control.new())
+
+	for key in current_dt:
+		populate_row(key)
+
+func populate_row(key):
+	var idx_lbl = Label.new()
+	idx_lbl.text = "1"
+	idx_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	grid_container.add_child(idx_lbl)
+	for i in range(0, 3):
+		populate_cell(i)
+	var menu_btn = MenuButton.new()
+	menu_btn.get_popup().add_item("Delete", 0)
+	menu_btn.icon = get_theme_icon("GuiTabMenuHl", "EditorIcons")
+	menu_btn.get_popup().id_pressed.connect(func(id): if id == 0: on_delete_btn_pressed(key))
+	grid_container.add_child(menu_btn)
+
+func populate_cell(i):
+	var types = ["example", true, 7.2]
+	var value = types[i]
+	var field_control
+	match(typeof(value)):
+		TYPE_BOOL:
+			field_control = CheckBox.new()
+			field_control.button_pressed = value
+		TYPE_STRING:
+			field_control = LineEdit.new()
+			field_control.text = value
+		TYPE_INT:
+			field_control = SpinBox.new()
+			field_control.allow_lesser = true
+			field_control.allow_greater = true
+			field_control.value = value
+		TYPE_FLOAT:
+			field_control = SpinBox.new()
+			field_control.step = 0.001
+			field_control.allow_lesser = true
+			field_control.allow_greater = true
+			field_control.value = value
+		TYPE_OBJECT:
+			field_control = EditorResourcePicker.new()
+			field_control.edited_resource = value
+			field_control.base_type = "Node"
+		_:
+			field_control = Label.new()
+			field_control.add_theme_color_override("font_color", Color(1, 0, 0))
+			field_control.text = "unknown type"
+	grid_container.add_child(field_control)
+
+func on_add_btn_pressed():
+	print("adding new row...")
+	on_datatable_selected({ "hi": "hello", "bye": "goodbye", "why": "goodbye"})
+
+func on_delete_btn_pressed(row):
+	print("deleting row ", row, "...")
+	on_datatable_selected({ "hi": "hello", "bye": "goodbye" })
+
+func on_new_dt_btn_pressed():
+	var editor = editor_plugin.get_editor_interface().get_editor_main_screen()
+	
+	var popup = PopupPanel.new()
+	editor.add_child(popup)
+	
+	var popup_vbox = VBoxContainer.new()
+	popup.add_child(popup_vbox)
+	
+	var resource_picker = EditorResourcePicker.new()
+	resource_picker.base_type = "DatatableRow"
+	popup_vbox.add_child(resource_picker)
+	
+	var type_btn = Button.new()
+	type_btn.text = "Select Base Row Type"
+	var on_type_btn_pressed_callback = func():
+		create_new_dt_resource(resource_picker.edited_resource)
+		popup.hide()
+	type_btn.pressed.connect(on_type_btn_pressed_callback)
+	popup_vbox.add_child(type_btn)
+	
+	popup.popup(new_dt_btn.get_global_rect())
+
+func create_new_dt_resource(resource_type: Resource):
+	if resource_type == null:
+		return
+	
+	var editor = editor_plugin.get_editor_interface().get_editor_main_screen()
+	
+	var new_dt = Datatable.new()
+	new_dt.default_row = resource_type
+	
+	var file_dialog = EditorFileDialog.new()
+	file_dialog.mode = EditorFileDialog.FILE_MODE_OPEN_FILE
+	file_dialog.access = EditorFileDialog.ACCESS_RESOURCES
+	file_dialog.title = "Save New Datatable"
+	file_dialog.add_filter("*.tres", "Datatable Resource")
+	file_dialog.file_selected.connect(func(p): ResourceSaver.save(new_dt, p))
+	editor.add_child(file_dialog)
+	
+	# Can only be called after the node has entered the tree
+	file_dialog.current_file = "new_dt.tres"
+	file_dialog.popup_centered()

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -229,7 +229,13 @@ func build_field_control(value: Variant, property: Dictionary, setter_callback: 
 				else:
 					field_control.text_changed.connect(setter_callback)
 		TYPE_INT, TYPE_FLOAT:
-			if property.hint == PROPERTY_HINT_ENUM:
+			if property.hint == PROPERTY_HINT_FLAGS:
+				field_control = DatatableEditorUtils.FlagsEdit.new()
+				field_control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+				field_control.value = value
+				field_control.hint_string = property.hint_string
+				field_control.value_changed.connect(setter_callback)
+			elif property.hint == PROPERTY_HINT_ENUM:
 				field_control = OptionButton.new()
 				field_control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 				var options = property.hint_string.split(",")

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -163,14 +163,14 @@ func populate_row(index: int, key):
 	var row = current_dt.data[key]
 	var row_properties = DatatableUtils.get_row_properties(row)
 	
-	var key_setter_callback = func(k):
+	var key_setter_callback = func(new_key):
 		match(current_dt.key_type):
 			TYPE_STRING:
-				k = String(k)
+				new_key = String(new_key)
 			TYPE_INT:
-				k = int(k)
-		if not current_dt.data.has(k):
-			DatatableUtils.move_row_stable(current_dt, key, k)
+				new_key = int(new_key)
+		if not current_dt.data.has(new_key):
+			DatatableUtils.move_row_stable(current_dt, key, new_key)
 			if DatatableUtils.validate_datatable_keys(current_dt):
 				ResourceSaver.save(current_dt)
 		refresh_table()
@@ -179,8 +179,8 @@ func populate_row(index: int, key):
 	grid_container.add_child(field_control)
 	
 	for property in row_properties:
-		var setter_callback = func(v):
-			row.set(property.name, v)
+		var setter_callback = func(new_value):
+			row.set(property.name, new_value)
 			ResourceSaver.save(current_dt)
 		field_control = build_field_control(row.get(property.name), property, setter_callback, false)
 		grid_container.add_child(field_control)
@@ -255,8 +255,8 @@ func build_field_control(value: Variant, property: Dictionary, setter_callback: 
 					var class_idx = allowed_types.find(value.get_class())
 					if not class_idx == -1:
 						field_control.select(class_idx)
-				var internal_setter_callback = func(v):
-					var selected_type = allowed_types[v]
+				var internal_setter_callback = func(new_value):
+					var selected_type = allowed_types[new_value]
 					setter_callback.call(ClassDB.instantiate(selected_type))
 				field_control.item_selected.connect(internal_setter_callback)
 		_:

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -18,14 +18,14 @@ func _init(plugin: EditorPlugin):
 	editor_plugin = plugin
 
 func _ready():
-	rebuild_layout()
+	build_layout()
 	refresh_table()
 
 func set_current_datatable(datatable: Datatable):
 	current_dt = datatable
 	refresh_table()
 
-func rebuild_layout():
+func build_layout():
 	for child in get_children():
 		child.queue_free()
 	
@@ -299,7 +299,6 @@ func get_default_key(type: Variant.Type):
 			return 0
 
 func on_refresh_btn_pressed():
-	rebuild_layout()
 	refresh_table()
 
 func on_add_btn_pressed():

--- a/addons/datatable/scripts/datatable_editor.gd
+++ b/addons/datatable/scripts/datatable_editor.gd
@@ -171,13 +171,19 @@ func populate_row(index: int, key):
 
 func build_field_control_for_key(value: Variant, type: Variant.Type):
 	var setter_callback = func(k):
+		match(current_dt.key_type):
+			TYPE_STRING:
+				k = String(k)
+			TYPE_INT:
+				k = int(k)
 		if not current_dt.data.has(k):
 			DatatableUtils.move_row_stable(current_dt, value, k)
-			ResourceSaver.save(current_dt)
+			if DatatableUtils.validate_datatable_keys(current_dt):
+				ResourceSaver.save(current_dt)
 		refresh_table()
 	var field_control
 	match(type):
-		TYPE_STRING_NAME:
+		TYPE_STRING:
 			field_control = LineEdit.new()
 			field_control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 			field_control.text = value
@@ -252,23 +258,10 @@ func build_field_control(value: Variant, property: Dictionary, setter_callback: 
 
 func get_default_key(type: Variant.Type):
 	match(type):
-		TYPE_STRING_NAME:
-			return StringName()
+		TYPE_STRING:
+			return String()
 		TYPE_INT:
 			return 0
-
-func move_row_stable(old_key, new_key):
-	var new_data = Dictionary()
-	var all_keys = current_dt.data.keys()
-	var all_values = current_dt.data.values()
-	var key_idx = all_keys.find(old_key)
-	
-	for i in range(0, all_keys.size()):
-		if i != key_idx:
-			new_data[all_keys[i]] = all_values[i]
-		else:
-			new_data[new_key] = all_values[i]
-	current_dt.data = new_data
 
 func on_add_btn_pressed():
 	var new_key = get_default_key(current_dt.key_type)
@@ -299,7 +292,7 @@ func on_new_dt_btn_pressed():
 	popup_grid.add_child(key_lbl)
 	
 	var key_type_options = OptionButton.new()
-	var dt_key_types = {"StringName": TYPE_STRING_NAME, "Int": TYPE_INT}
+	var dt_key_types = {"String": TYPE_STRING, "Int": TYPE_INT}
 	for type in dt_key_types:
 		key_type_options.add_item(type)
 	popup_grid.add_child(key_type_options)

--- a/addons/datatable/scripts/datatable_editor_utils.gd
+++ b/addons/datatable/scripts/datatable_editor_utils.gd
@@ -33,17 +33,7 @@ class VectorEdit extends HBoxContainer:
 	
 	func build_component_spinbox(idx):
 		var internal_setter_callback = func(v):
-			var new_vec = vector
-			match(idx):
-				0:
-					new_vec.x = v
-				1:
-					new_vec.y = v
-				2:
-					new_vec.z = v
-				3:
-					new_vec.w = v
-			vector = new_vec
+			set_component_value(idx, v)
 			build_layout()
 			value_changed.emit(vector)
 		var spinbox = SpinBox.new()
@@ -74,3 +64,14 @@ class VectorEdit extends HBoxContainer:
 				return vector.z
 			3:
 				return vector.w
+	
+	func set_component_value(idx, v):
+		match(idx):
+			0:
+				vector.x = v
+			1:
+				vector.y = v
+			2:
+				vector.z = v
+			3:
+				vector.w = v

--- a/addons/datatable/scripts/datatable_editor_utils.gd
+++ b/addons/datatable/scripts/datatable_editor_utils.gd
@@ -32,8 +32,8 @@ class VectorEdit extends HBoxContainer:
 		return panel_container
 	
 	func build_component_spinbox(idx):
-		var internal_setter_callback = func(v):
-			set_component_value(idx, v)
+		var internal_setter_callback = func(new_value):
+			set_component_value(idx, new_value)
 			build_layout()
 			value_changed.emit(vector)
 		var spinbox = SpinBox.new()
@@ -65,13 +65,13 @@ class VectorEdit extends HBoxContainer:
 			3:
 				return vector.w
 	
-	func set_component_value(idx, v):
+	func set_component_value(idx, value):
 		match(idx):
 			0:
-				vector.x = v
+				vector.x = value
 			1:
-				vector.y = v
+				vector.y = value
 			2:
-				vector.z = v
+				vector.z = value
 			3:
-				vector.w = v
+				vector.w = value

--- a/addons/datatable/scripts/datatable_editor_utils.gd
+++ b/addons/datatable/scripts/datatable_editor_utils.gd
@@ -1,0 +1,76 @@
+class_name DatatableEditorUtils
+
+class VectorEdit extends HBoxContainer:
+	
+	signal value_changed(value)
+	
+	const component_names = ["x", "y", "z", "w"]
+	
+	var vector: Variant
+	
+	func _ready():
+		build_layout()
+	
+	func build_layout():
+		for child in get_children():
+			child.queue_free()
+		for i in range(0, get_component_count()):
+			add_child(build_component_label(i))
+			add_child(build_component_spinbox(i))
+	
+	func build_component_label(idx):
+		var panel_container = PanelContainer.new()
+		var stylebox = get_theme_stylebox("label_bg", "EditorSpinSlider")
+		panel_container.add_theme_stylebox_override("panel", stylebox)
+		
+		var comp_label = Label.new()
+		var component_name = component_names[idx]
+		comp_label.text = component_name
+		var color = get_theme_color("property_color_" + component_name, "Editor")
+		comp_label.add_theme_color_override("font_color", color)
+		panel_container.add_child(comp_label)
+		return panel_container
+	
+	func build_component_spinbox(idx):
+		var internal_setter_callback = func(v):
+			var new_vec = vector
+			match(idx):
+				0:
+					new_vec.x = v
+				1:
+					new_vec.y = v
+				2:
+					new_vec.z = v
+				3:
+					new_vec.w = v
+			vector = new_vec
+			build_layout()
+			value_changed.emit(vector)
+		var spinbox = SpinBox.new()
+		spinbox.step = 0.001
+		spinbox.allow_lesser = true
+		spinbox.allow_greater = true
+		spinbox.value = get_component_value(idx)
+		spinbox.value_changed.connect(internal_setter_callback)
+		return spinbox
+	
+	func get_component_count() -> int:
+		match(typeof(vector)):
+			TYPE_VECTOR2, TYPE_VECTOR2I:
+				return 2
+			TYPE_VECTOR3, TYPE_VECTOR3I:
+				return 3
+			TYPE_VECTOR4, TYPE_VECTOR4I:
+				return 4
+		return 0
+	
+	func get_component_value(idx):
+		match(idx):
+			0:
+				return vector.x
+			1:
+				return vector.y
+			2:
+				return vector.z
+			3:
+				return vector.w

--- a/addons/datatable/scripts/datatable_editor_utils.gd
+++ b/addons/datatable/scripts/datatable_editor_utils.gd
@@ -1,5 +1,34 @@
 class_name DatatableEditorUtils
 
+class FlagsEdit extends MenuButton:
+	
+	signal value_changed(value)
+	
+	var value: int
+	var hint_string: String
+	
+	func _ready():
+		var on_pressed = func(idx):
+			var flags = hint_string.split(",")
+			var flag = int(flags[idx])
+			value = value & ~flag if value & flag else value | flag
+			build_layout()
+			value_changed.emit(value)
+		get_popup().id_pressed.connect(on_pressed)
+		build_layout()
+	
+	func build_layout():
+		get_popup().clear()
+		get_popup().hide_on_checkable_item_selection = false
+		
+		text = "Edit (%s)" % value
+		var flags = hint_string.split(",")
+		for i in range(0, flags.size()):
+			var flag_details = flags[i].split(":")
+			var is_set = value & int(flag_details[1])
+			get_popup().add_check_item(flag_details[0], i)
+			get_popup().set_item_checked(i, is_set)
+
 class VectorEdit extends HBoxContainer:
 	
 	signal value_changed(value)

--- a/addons/datatable/scripts/datatable_inspector_plugin.gd
+++ b/addons/datatable/scripts/datatable_inspector_plugin.gd
@@ -1,0 +1,9 @@
+extends EditorInspectorPlugin
+
+signal datatable_inspected(datatable: Datatable)
+
+func _can_handle(object):
+	return object is Datatable
+
+func _parse_begin(object):
+	datatable_inspected.emit(object)

--- a/addons/datatable/scripts/datatable_row.gd
+++ b/addons/datatable/scripts/datatable_row.gd
@@ -1,8 +1,14 @@
 class_name DatatableRow extends Resource
+## Row schema definition for usage with [Datatable] resources.
+##
+## Serves as the schema definition base for the [Datatable] resource, where any
+## exported members define its "columns".
 
+## Returns the script level class name of the row type.
 func get_name() -> String:
 	return DatatableUtils.get_row_name(self)
 
+## Returns an [Array] of script properties for each member of the row.
 func get_properties() -> Array:
 	return DatatableUtils.get_row_properties(self)
 

--- a/addons/datatable/scripts/datatable_row.gd
+++ b/addons/datatable/scripts/datatable_row.gd
@@ -1,7 +1,14 @@
 class_name DatatableRow extends Resource
 
-func get_row_name() -> String:
+func get_name() -> String:
 	return DatatableUtils.get_row_name(self)
 
-func get_row_properties() -> Array:
+func get_properties() -> Array:
 	return DatatableUtils.get_row_properties(self)
+
+func _to_string() -> String:
+	var props = get_properties()
+	var display_str = "{"
+	for prop in props:
+		display_str += "%s: %s," % [prop.name, get(prop.name)]
+	return display_str.trim_suffix(",") + "}"

--- a/addons/datatable/scripts/datatable_row.gd
+++ b/addons/datatable/scripts/datatable_row.gd
@@ -1,0 +1,9 @@
+class_name DatatableRow extends Resource
+
+func get_row_properties() -> Array:
+	var row_props: Array = []
+	var prop_list = get_script().get_script_property_list()
+	for prop in prop_list:
+		if prop.type != TYPE_NIL:
+			row_props.append({"name": prop.name, "type": prop.type, "value":get(prop.name)})
+	return row_props

--- a/addons/datatable/scripts/datatable_row.gd
+++ b/addons/datatable/scripts/datatable_row.gd
@@ -1,9 +1,7 @@
 class_name DatatableRow extends Resource
 
+func get_row_name() -> String:
+	return DatatableUtils.get_row_name(self)
+
 func get_row_properties() -> Array:
-	var row_props: Array = []
-	var prop_list = get_script().get_script_property_list()
-	for prop in prop_list:
-		if prop.type != TYPE_NIL:
-			row_props.append({"name": prop.name, "type": prop.type, "value":get(prop.name)})
-	return row_props
+	return DatatableUtils.get_row_properties(self)

--- a/addons/datatable/scripts/datatable_utils.gd
+++ b/addons/datatable/scripts/datatable_utils.gd
@@ -13,3 +13,16 @@ static func get_row_properties(row: DatatableRow) -> Array:
 		if prop.type != TYPE_NIL:
 			row_props.append(prop)
 	return row_props
+
+static func move_row_stable(datatable: Datatable, old_key, new_key):
+	var new_data = Dictionary()
+	var all_keys = datatable.data.keys()
+	var all_values = datatable.data.values()
+	var key_idx = all_keys.find(old_key)
+	
+	for i in range(0, all_keys.size()):
+		if i != key_idx:
+			new_data[all_keys[i]] = all_values[i]
+		else:
+			new_data[new_key] = all_values[i]
+	datatable.data = new_data

--- a/addons/datatable/scripts/datatable_utils.gd
+++ b/addons/datatable/scripts/datatable_utils.gd
@@ -2,7 +2,7 @@ class_name DatatableUtils
 
 static func get_row_name(row: DatatableRow) -> String:
 	var source = row.get_script().source_code
-	var regex = RegEx.create_from_string("class_name ([A-z]*)")
+	var regex = RegEx.create_from_string("class_name ([A-z0-9]*)")
 	var result = regex.search(source)
 	return result.get_string(1) if result else "Unknown"
 
@@ -11,5 +11,5 @@ static func get_row_properties(row: DatatableRow) -> Array:
 	var prop_list = row.get_script().get_script_property_list()
 	for prop in prop_list:
 		if prop.type != TYPE_NIL:
-			row_props.append({"name": prop.name, "type": prop.type, "value":row.get(prop.name)})
+			row_props.append(prop)
 	return row_props

--- a/addons/datatable/scripts/datatable_utils.gd
+++ b/addons/datatable/scripts/datatable_utils.gd
@@ -1,0 +1,15 @@
+class_name DatatableUtils
+
+static func get_row_name(row: DatatableRow) -> String:
+	var source = row.get_script().source_code
+	var regex = RegEx.create_from_string("class_name ([A-z]*)")
+	var result = regex.search(source)
+	return result.get_string(1) if result else "Unknown"
+
+static func get_row_properties(row: DatatableRow) -> Array:
+	var row_props: Array = []
+	var prop_list = row.get_script().get_script_property_list()
+	for prop in prop_list:
+		if prop.type != TYPE_NIL:
+			row_props.append({"name": prop.name, "type": prop.type, "value":row.get(prop.name)})
+	return row_props

--- a/addons/datatable/scripts/datatable_utils.gd
+++ b/addons/datatable/scripts/datatable_utils.gd
@@ -1,11 +1,18 @@
 class_name DatatableUtils
+## Static utility functions for use with the [Datatable] resource.
+##
+## Contains static functions useful for operating the [Datatable] and
+## [DatatableRow] resources, mirroring or containing many functions of the class
+## itself, in order to allow for thier execution outside of runtime.
 
+## Returns the script level class name for the type of a given row.
 static func get_row_name(row: DatatableRow) -> String:
 	var source = row.get_script().source_code
 	var regex = RegEx.create_from_string("class_name ([A-z0-9]*)")
 	var result = regex.search(source)
 	return result.get_string(1) if result else "Unknown"
 
+## Returns an [Array] of script properties for each member of a given row.
 static func get_row_properties(row: DatatableRow) -> Array:
 	var row_props: Array = []
 	var prop_list = row.get_script().get_script_property_list()
@@ -14,6 +21,9 @@ static func get_row_properties(row: DatatableRow) -> Array:
 			row_props.append(prop)
 	return row_props
 
+## Replaces the key of a given row by key, preserving stable ordering in the
+## process. Note that in general the [Datatable] resource does not guarantee
+## order, and this operation is slow and should be avoided at runtime.
 static func move_row_stable(datatable: Datatable, old_key, new_key):
 	var new_data = Dictionary()
 	var all_keys = datatable.data.keys()
@@ -27,6 +37,9 @@ static func move_row_stable(datatable: Datatable, old_key, new_key):
 			new_data[new_key] = all_values[i]
 	datatable.data = new_data
 
+## Returns [code]true[/code] if all keys are of the correct type for a given
+## datatable, [code]false[/code] otherwise, generating an error specifying the
+## first offending row and its particular issue.
 static func validate_datatable_keys(datatable: Datatable) -> bool:
 	var default_props = get_row_properties(datatable.default_row)
 	for key in datatable.data.keys():

--- a/addons/datatable/scripts/datatable_utils.gd
+++ b/addons/datatable/scripts/datatable_utils.gd
@@ -26,3 +26,11 @@ static func move_row_stable(datatable: Datatable, old_key, new_key):
 		else:
 			new_data[new_key] = all_values[i]
 	datatable.data = new_data
+
+static func validate_datatable_keys(datatable: Datatable) -> bool:
+	var default_props = get_row_properties(datatable.default_row)
+	for key in datatable.data.keys():
+		if typeof(key) != datatable.key_type:
+			push_error("Found bad key ", key, "type should be ", datatable.key_type, " got ", typeof(key))
+			return false
+	return true

--- a/assets/common/utils.gd
+++ b/assets/common/utils.gd
@@ -1,4 +1,9 @@
 class_name Utils
 
+const VERSION_CONFIG_SETTING: String = "application/config/version"
+
 static func push_info(arg1 = "", arg2 = "", arg3 = "", arg4 = "", arg5 = "", arg6 = "", arg7 = "", arg8 = ""):
 	print(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+
+static func get_version() -> String:
+	return ProjectSettings.get_setting(VERSION_CONFIG_SETTING)

--- a/assets/debug/scenes/debug_display.tscn
+++ b/assets/debug/scenes/debug_display.tscn
@@ -20,6 +20,21 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
+[node name="VersionLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -54.0
+offset_top = -33.0
+offset_right = -9.0
+offset_bottom = -7.0
+grow_horizontal = 0
+grow_vertical = 0
+text = "v0.0.0"
+
 [node name="ExampleDebugPanel" parent="." instance=ExtResource("2_tew68")]
 layout_mode = 0
 offset_left = 117.0

--- a/assets/debug/scripts/debug_panel.gd
+++ b/assets/debug/scripts/debug_panel.gd
@@ -3,6 +3,7 @@ extends Control
 signal refresh
 
 func _ready():
+	$VersionLabel.text = "v" + Utils.get_version()
 	set_open(false)
 
 func _input(event):

--- a/assets/dice/models/d4/dice_d4_tex.png.import
+++ b/assets/dice/models/d4/dice_d4_tex.png.import
@@ -4,16 +4,15 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://boxplkyalrvtv"
 path.s3tc="res://.godot/imported/dice_d4_tex.png-4921bc4c2b5ed7c1739e992f52e0956a.s3tc.ctex"
-path.etc2="res://.godot/imported/dice_d4_tex.png-4921bc4c2b5ed7c1739e992f52e0956a.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc", "etc2_astc"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/dice/models/d4/dice_d4_tex.png"
-dest_files=["res://.godot/imported/dice_d4_tex.png-4921bc4c2b5ed7c1739e992f52e0956a.s3tc.ctex", "res://.godot/imported/dice_d4_tex.png-4921bc4c2b5ed7c1739e992f52e0956a.etc2.ctex"]
+dest_files=["res://.godot/imported/dice_d4_tex.png-4921bc4c2b5ed7c1739e992f52e0956a.s3tc.ctex"]
 
 [params]
 

--- a/assets/dice/models/d6/dice_d6_tex.png.import
+++ b/assets/dice/models/d6/dice_d6_tex.png.import
@@ -4,16 +4,15 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://cdkuw5fmhyfc6"
 path.s3tc="res://.godot/imported/dice_d6_tex.png-d2baaa64b88d8f8fb4009e7132465d71.s3tc.ctex"
-path.etc2="res://.godot/imported/dice_d6_tex.png-d2baaa64b88d8f8fb4009e7132465d71.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc", "etc2_astc"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/dice/models/d6/dice_d6_tex.png"
-dest_files=["res://.godot/imported/dice_d6_tex.png-d2baaa64b88d8f8fb4009e7132465d71.s3tc.ctex", "res://.godot/imported/dice_d6_tex.png-d2baaa64b88d8f8fb4009e7132465d71.etc2.ctex"]
+dest_files=["res://.godot/imported/dice_d6_tex.png-d2baaa64b88d8f8fb4009e7132465d71.s3tc.ctex"]
 
 [params]
 

--- a/assets/levels/level_bindings.gd
+++ b/assets/levels/level_bindings.gd
@@ -11,8 +11,8 @@ func _ready():
 		get_node(building).selected.connect(on_building_selected)
 	dice_spawner.roll_completed.connect(on_roll_completed)
 	
-	var dt = load("res://addons/datatable/example/example_dt.tres")
-	var row = dt.data["test"] 
+	var dt = load("res://addons/datatable/example/example2_dt.tres")
+	var row = dt.data[dt.data.keys()[0]]
 	var props = row.get_row_properties()
 	for prop in props:
 		print(prop.name)

--- a/assets/levels/level_bindings.gd
+++ b/assets/levels/level_bindings.gd
@@ -11,8 +11,8 @@ func _ready():
 		get_node(building).selected.connect(on_building_selected)
 	dice_spawner.roll_completed.connect(on_roll_completed)
 	
-	var dt = load("res://addons/datatable/example/example1_dt.tres")
-	for row in dt.get_iter():
+	var example_dt = load("res://addons/datatable/example/example1_dt.tres")
+	for row in example_dt:
 		print(row)
 
 func _input(event):

--- a/assets/levels/level_bindings.gd
+++ b/assets/levels/level_bindings.gd
@@ -10,6 +10,14 @@ func _ready():
 	for building in buildings:
 		get_node(building).selected.connect(on_building_selected)
 	dice_spawner.roll_completed.connect(on_roll_completed)
+	
+	var dt = load("res://addons/datatable/example/example_dt.tres")
+	var row = dt.data["test"] 
+	var props = row.get_row_properties()
+	for prop in props:
+		print(prop.name)
+		print(prop.type)
+		print(prop.value)
 
 func _input(event):
 	if event.is_action_released("rmb_down"):

--- a/assets/levels/level_bindings.gd
+++ b/assets/levels/level_bindings.gd
@@ -15,8 +15,11 @@ func _ready():
 	for row in example_dt:
 		print(row)
 	
-	var player_row = example_dt.get_row("player")
+	var player_row: ExampleRow1 = example_dt.get_row("player")
 	print(player_row.move_speed)
+	var s = ClassDB.instantiate(player_row.debug_shape)
+	print(s)
+	s.queue_free()
 
 func _input(event):
 	if event.is_action_released("rmb_down"):

--- a/assets/levels/level_bindings.gd
+++ b/assets/levels/level_bindings.gd
@@ -11,13 +11,9 @@ func _ready():
 		get_node(building).selected.connect(on_building_selected)
 	dice_spawner.roll_completed.connect(on_roll_completed)
 	
-	var dt = load("res://addons/datatable/example/example2_dt.tres")
-	var row = dt.data[dt.data.keys()[0]]
-	var props = row.get_row_properties()
-	for prop in props:
-		print(prop.name)
-		print(prop.type)
-		print(prop.value)
+	var dt = load("res://addons/datatable/example/example1_dt.tres")
+	for row in dt.get_iter():
+		print(row)
 
 func _input(event):
 	if event.is_action_released("rmb_down"):

--- a/assets/levels/level_bindings.gd
+++ b/assets/levels/level_bindings.gd
@@ -14,6 +14,9 @@ func _ready():
 	var example_dt = load("res://addons/datatable/example/example1_dt.tres")
 	for row in example_dt:
 		print(row)
+	
+	var player_row = example_dt.get_row("player")
+	print(player_row.move_speed)
 
 func _input(event):
 	if event.is_action_released("rmb_down"):

--- a/assets/persistence/savegame.gd
+++ b/assets/persistence/savegame.gd
@@ -8,3 +8,7 @@ const Metadata = preload("res://assets/persistence/metadata.gd")
 
 const ExampleData = preload("res://assets/persistence/example_data.gd")
 @onready var example: ExampleData = ExampleData.new(self)
+
+func _exit_tree():
+	metadata.free()
+	example.free()

--- a/assets/validation/validation.gd
+++ b/assets/validation/validation.gd
@@ -1,4 +1,4 @@
-class_name ValidationManager
+class_name ValidationManager extends Object
 
 const Utils = preload("res://assets/common/utils.gd") 
 const validations = []
@@ -12,13 +12,14 @@ func run_all_validations() -> bool:
 		if not v.run_validations():
 			push_error("    VALIDATION FAILED")
 			result = false
+		v.queue_free()
 	if result:
 		Utils.push_info("All validations passed!")
 	else:
 		push_error("Some validations failed - see above for more info.")
 	return result
 
-class Validation:
+class Validation extends Object:
 	
 	func get_name() -> String:
 		return "Validation"

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="RNG Stronghold"
 run/main_scene="res://assets/levels/main_level.tscn"
-config/features=PackedStringArray("4.0", "Forward Plus")
+config/features=PackedStringArray("4.1", "Forward Plus")
 config/icon="res://assets/common/application_icon.svg"
 config/version="0.1.5"
 
@@ -37,12 +37,12 @@ import/blender/enabled=false
 
 lmb_down={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"pressed":false,"double_click":false,"script":null)
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
 rmb_down={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"pressed":false,"double_click":false,"script":null)
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
 toggle_debug={

--- a/project.godot
+++ b/project.godot
@@ -14,7 +14,7 @@ config/name="RNG Stronghold"
 run/main_scene="res://assets/levels/main_level.tscn"
 config/features=PackedStringArray("4.0", "Forward Plus")
 config/icon="res://assets/common/application_icon.svg"
-config/version="0.1.4"
+config/version="0.1.5"
 
 [autoload]
 

--- a/project.godot
+++ b/project.godot
@@ -27,7 +27,7 @@ window/size/window_height_override=1080
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/persistent_data/plugin.cfg", "res://addons/datatable/plugin.cfg")
+enabled=PackedStringArray("res://addons/datatable/plugin.cfg", "res://addons/persistent_data/plugin.cfg")
 
 [filesystem]
 

--- a/project.godot
+++ b/project.godot
@@ -27,7 +27,7 @@ window/size/window_height_override=1080
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/persistent_data/plugin.cfg")
+enabled=PackedStringArray("res://addons/persistent_data/plugin.cfg", "res://addons/datatable/plugin.cfg")
 
 [filesystem]
 

--- a/scripts/apply_version.gd
+++ b/scripts/apply_version.gd
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S godot -s
 extends SceneTree
 
+const Utils = preload("res://assets/common/utils.gd")
 const EXPORT_PRESETS_FILE: String = "res://export_presets.cfg"
-const VERSION_CONFIG_SETTING: String = "application/config/version"
 
 func _init():
 	var result = apply_version()
@@ -13,7 +13,7 @@ func apply_version() -> bool:
 	if export_presets.load(EXPORT_PRESETS_FILE) != OK:
 		return false
 	
-	var version: String = ProjectSettings.get_setting(VERSION_CONFIG_SETTING)
+	var version: String = Utils.get_version()
 	var short_version = ".".join(version.rsplit("."))
 	var long_version = (".".join(version.split(".").slice(0, 3))) + ".0"
 	

--- a/scripts/run_validations.gd
+++ b/scripts/run_validations.gd
@@ -6,4 +6,5 @@ const ValidationManager = preload("res://assets/validation/validation.gd")
 func _init():
 	var manager = ValidationManager.new()
 	var result = manager.run_all_validations()
+	manager.queue_free()
 	quit(0 if result else 1)

--- a/scripts/run_validations.gd
+++ b/scripts/run_validations.gd
@@ -6,5 +6,5 @@ const ValidationManager = preload("res://assets/validation/validation.gd")
 func _init():
 	var manager = ValidationManager.new()
 	var result = manager.run_all_validations()
-	manager.queue_free()
+	manager.free()
 	quit(0 if result else 1)


### PR DESCRIPTION
### Pull Request Description
<!-- Provide a brief description of what this PR does and how it can be tested below -->
This PR adds support for a keyed, tabular data storage resource, named `Datatable`, along with an editor plugin that opens up datatable resources within the editor using a custom datatable editor. To create a new datatable, simply define a new `DatatableRow` as so:
```gdscript
class_name ExampleRow2 extends DatatableRow

enum DamageType { FIRE, WATER, NECROTIC }

@export var is_enabled: bool
@export var effect_offset: Vector4
@export var effect_colour: Color
@export var damage_type: DamageType
```

Once saved, open up the datatable editor tab in the bottom panel and select the "new table" button.

<img width="961" alt="Screenshot 2023-07-04 at 6 50 47 pm" src="https://github.com/CapsCollective/rng-stronghold/assets/9414994/f646f8e1-d8d1-4b2b-9634-bb83a651254b">

Select the desired key type and row type (if your new row type does not initially appear in the dropdown the `ClassDB` may require refresh), and save the newly generated table.

<img width="402" alt="Screenshot 2023-07-04 at 6 51 44 pm" src="https://github.com/CapsCollective/rng-stronghold/assets/9414994/4eba7678-2aa8-4e3e-9cc0-79d551570a65">

Clicking on the datatable resource in the file system panel, should then bring it up in the datatable editor as below (note that no rows will initially exist for the table):

<img width="955" alt="Screenshot 2023-07-04 at 6 48 28 pm" src="https://github.com/CapsCollective/rng-stronghold/assets/9414994/bcb640b5-4f53-4cec-9b0b-bce2cc033902">

The datatable can be used at runtime as so:
```gdscript
var example_dt = load("res://addons/datatable/example/example1_dt.tres")
for row in example_dt:
	print(row)
var player_row = example_dt.get_row("player")
print(player_row.move_speed)
```

Note that the use of `get_row` is the recommended access method for the resource given that it is internally stored as a dictionary.

In addition to the features described above, the editor also supports the following export annotations:
```gdscript
@export_range(0, 10) var priority: int # Ranged export of values between 0 and 10
@export_range(-1, 1, 0.01) var move_speed: float # Ranged export of values between -1 and 1, rounding to nearest 0.01
@export_enum("class_name", "CSGShape3D") var debug_shape: String # Object type name String export (base type in this case would be CSGShape3D)
@export_flags("Fire:1", "Ice:2", "Poison:4") var weaknesses: int # Named bitfield exports (evaluates to all selected values &'ed)
```

The datatable editor officially supports the following `DatatableRow` member types at this stage:
- `bool`
- `int` (including bitfield values)
- `float`
- `enum`
- `String`
- `StringName`
- `Color`
- `Resource` (or any resource inheriting type)
- `Vector2`
- `Vector3`
- `Vector4`
- `Vector2i`
- `Vector3i`
- `Vector4i`

The following types are unsupported at this stage:
- `Rect2`
- `Rect2i`
- `Transform2D`
- `Plane`
- `Quaternion`
- `AABB`
- `Basis`
- `Transform3D`
- `Projection`
- `NodePath`
- `Object` (this may in fact cause a memory leak)
- `Dictionary`
- `Array`
- `PackedByteArray`
- `PackedInt32Array`
- `PackedInt64Array`
- `PackedFloat32Array`
- `PackedFloat64Array`
- `PackedStringArray`
- `PackedVector2Array`
- `PackedVector3Array`
- `PackedColorArray`

<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Implemented walls mechanic")
- [x] linked to its related issue
- [x] assigned a reviewer from the team

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] pulled to the reviewer's machine and reasonably tested
- [x] read through and approved by a reviewer
- [x] bumped in project version over the [latest release](https://github.com/CapsCollective/rng-stronghold/releases) (i.e. vX.Y.Z for major, minor or patch)

_Note: for new features, use minor (Y), and for bug fixes or small changes, use patch (Z). Bumping the minor version should also reset the patch version to zero, so v1.2.4, would become v1.3.0. See [semantic versioning](https://semver.org) for more info._

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
